### PR TITLE
Add "merge activist"

### DIFF
--- a/frontend/ActivistList.vue
+++ b/frontend/ActivistList.vue
@@ -40,7 +40,7 @@
     </table>
     <modal
        name="merge-activist-modal"
-       :height="600"
+       :height="650"
        classes="no-background-color"
        @opened="modalOpened"
        @closed="modalClosed"
@@ -53,12 +53,19 @@
           <div class="modal-body">
             <p>Merging activists is used to combine redundant activist entries</p>
             <p>
-              When you merge this activist into another activist, all of this activist's
-              attendance data will be merged into the other activist. Other data (e.g.
-              email, location, etc) is <strong>NOT</strong> merged.
+              Merging this activist does two things:
+            </p>
+            <ul>
+              <li>all of this activist&#39;s attendance data will be merged into the target activist</li>
+              <li>this activist will be hidden</li>
+            </ul>
+            <p>
+              Non-attendance data (e.g. email, location, etc) is <strong>NOT</strong> merged.
             </p>
             <p>Merge {{currentActivist.name}} into another activist:</p>
-            <select id="merged-activist" class="filter-margin" style="min-width: 200px"></select>
+            <p>
+              Target activist: <select id="merge-target-activist" class="filter-margin" style="min-width: 200px"></select>
+            </p>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-secondary" @click="hideModal">Close</button>
@@ -214,8 +221,8 @@ export default {
       this.currentActivist = {};
     },
     confirmMergeActivistModal: function() {
-      var mergedActivistName = $("#merged-activist").val();
-      if (!mergedActivistName) {
+      var targetActivistName = $("#merge-target-activist").val();
+      if (!targetActivistName) {
         flashMessage("Must choose an activist to merge into", true);
         return;
       }
@@ -228,7 +235,7 @@ export default {
         contentType: "application/json",
         data: JSON.stringify({
           current_activist_id: this.currentActivist.id,
-          merged_activist_name: mergedActivistName,
+          target_activist_name: targetActivistName,
         }),
         success: (data) => {
           this.disableConfirmButton = false;
@@ -238,6 +245,7 @@ export default {
             flashMessage("Error: " + parsed.message, true);
             return;
           }
+          flashMessage(this.currentActivist.name + " was merged into " + targetActivistName);
 
           // Remove activist from list.
           this.activists = this.activists.slice(0, this.activistIndex).concat(
@@ -266,6 +274,7 @@ export default {
             flashMessage("Error: " + parsed.message, true);
             return;
           }
+          flashMessage(this.currentActivist.name + " was hidden");
 
           // Remove activist from list.
           this.activists = this.activists.slice(0, this.activistIndex).concat(
@@ -297,6 +306,7 @@ export default {
             flashMessage("Error: " + parsed.message, true);
             return;
           }
+          flashMessage(this.currentActivist.name + " saved");
 
           // status === "success"
           Vue.set(this.activists, this.activistIndex, parsed.activist);
@@ -321,7 +331,7 @@ export default {
         // just going to wait for a certain amount of time before
         // firing.
         setTimeout(() => {
-          initActivistSelect('#merged-activist', this.currentActivist.name);
+          initActivistSelect('#merge-target-activist', this.currentActivist.name);
         }, 100);
       }
 

--- a/frontend/chosen_utils.js
+++ b/frontend/chosen_utils.js
@@ -1,0 +1,56 @@
+import 'bootstrap-chosen/bootstrap-chosen.css';
+import 'chosen-js'; // Attaches to jQuery when it's imported.
+
+// From chosen-js
+function chosenBrowserIsSupported() {
+  if ("Microsoft Internet Explorer" === window.navigator.appName) {
+    return document.documentMode >= 8;
+  }
+  if (/iP(od|hone)/i.test(window.navigator.userAgent) ||
+      /IEMobile/i.test(window.navigator.userAgent) ||
+      /Windows Phone/i.test(window.navigator.userAgent) ||
+      /BlackBerry/i.test(window.navigator.userAgent) ||
+      /BB10/i.test(window.navigator.userAgent) ||
+      /Android.*Mobile/i.test(window.navigator.userAgent)) {
+    return false;
+  }
+  return true;
+}
+
+export function initActivistSelect(selector, ignoreActivistName) {
+  var $selector = $(selector);
+
+  // Chosen-js isn't supported on mobile browsers. We need to add the
+  // class "form-control" to the selector if it isn't supported so the
+  // selector doesn't look super ugly.
+  if (!chosenBrowserIsSupported()) {
+    $selector.addClass('form-control');
+  }
+
+  $.ajax({
+    url: "/activist_names/get",
+    method: "GET",
+    dataType: "json",
+    success: function(data) {
+      var activistNames = data.activist_names;
+
+      activistNames.unshift("");
+
+      for (var i = 0; i < activistNames.length; i++) {
+        if (activistNames[i] == ignoreActivistName) {
+          continue;
+        }
+
+        $selector[0].options.add(new Option(activistNames[i]));
+      }
+
+      $selector.chosen({
+        allow_single_deselect: true,
+        inherit_select_classes: true,
+      });
+    },
+    error: function() {
+      flashMessage("Error: could not load activist names", true);
+    },
+  });
+}

--- a/frontend/chosen_utils.js
+++ b/frontend/chosen_utils.js
@@ -34,6 +34,9 @@ export function initActivistSelect(selector, ignoreActivistName) {
     success: function(data) {
       var activistNames = data.activist_names;
 
+      // The first item needs to be empty so that the selector
+      // defaults to not being filled in. Otherwise, it defaults to
+      // the first item in the list.
       activistNames.unshift("");
 
       for (var i = 0; i < activistNames.length; i++) {

--- a/frontend/event_list.js
+++ b/frontend/event_list.js
@@ -1,22 +1,5 @@
 import {flashMessage} from 'flash_message';
-import 'bootstrap-chosen/bootstrap-chosen.css';
-import 'chosen-js'; // Attaches to jQuery when it's imported.
-
-// From chosen-js
-function chosenBrowserIsSupported() {
-  if ("Microsoft Internet Explorer" === window.navigator.appName) {
-    return document.documentMode >= 8;
-  }
-  if (/iP(od|hone)/i.test(window.navigator.userAgent) ||
-      /IEMobile/i.test(window.navigator.userAgent) ||
-      /Windows Phone/i.test(window.navigator.userAgent) ||
-      /BlackBerry/i.test(window.navigator.userAgent) ||
-      /BB10/i.test(window.navigator.userAgent) ||
-      /Android.*Mobile/i.test(window.navigator.userAgent)) {
-    return false;
-  }
-  return true;
-}
+import {initActivistSelect} from 'chosen_utils';
 
 export function confirmDeleteEvent(eventID) {
   var eventRow = $("#event-id-" + eventID);
@@ -177,42 +160,8 @@ function initDateRange() {
 
 }
 
-function initEventActivistSelect() {
-  var $selector = $("#event-activist");
-
-  // Chosen-js isn't supported on mobile browsers. We need to add the
-  // class "form-control" to the selector if it isn't supported so the
-  // selector doesn't look super ugly.
-  if (!chosenBrowserIsSupported()) {
-    $selector.addClass('form-control');
-  }
-
-  $.ajax({
-    url: "/activist_names/get",
-    method: "GET",
-    dataType: "json",
-    success: function(data) {
-      var activistNames = data.activist_names;
-
-      activistNames.unshift("");
-
-      for (var i = 0; i < activistNames.length; i++) {
-        $selector[0].options.add(new Option(activistNames[i]));
-      }
-
-      $selector.chosen({
-        allow_single_deselect: true,
-        inherit_select_classes: true,
-      });
-    },
-    error: function() {
-      flashMessage("Error: could not load activist names", true);
-    },
-  });
-}
-
 export function initializeApp() {
   initDateRange();
-  initEventActivistSelect();
+  initActivistSelect("#event-activist");
   eventListRequest();
 }

--- a/main.go
+++ b/main.go
@@ -131,6 +131,7 @@ func router() *mux.Router {
 	router.Handle("/activist/list", alice.New(main.apiAuthMiddleware).ThenFunc(main.ActivistListHandler))
 	router.Handle("/activist/save", alice.New(main.apiAuthMiddleware).ThenFunc(main.ActivistSaveHandler))
 	router.Handle("/activist/hide", alice.New(main.apiAuthMiddleware).ThenFunc(main.ActivistHideHandler))
+	router.Handle("/activist/merge", alice.New(main.apiAuthMiddleware).ThenFunc(main.ActivistMergeHandler))
 	router.Handle("/leaderboard/list", alice.New(main.apiAuthMiddleware).ThenFunc(main.LeaderboardListHandler))
 
 	if config.IsProd {
@@ -374,8 +375,38 @@ func (c MainController) ActivistHideHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	out := map[string]interface{}{
-		"status":    "success",
-		"activists": nil,
+		"status": "success",
+	}
+	writeJSON(w, out)
+}
+
+func (c MainController) ActivistMergeHandler(w http.ResponseWriter, r *http.Request) {
+	var activistMergeData struct {
+		CurrentActivistID  int    `json:"current_activist_id"`
+		MergedActivistName string `json:"merged_activist_name"`
+	}
+	err := json.NewDecoder(r.Body).Decode(&activistMergeData)
+	if err != nil {
+		sendErrorMessage(w, err)
+		return
+	}
+
+	// First, we need to get the activist ID for the merged
+	// activist.
+	mergedUser, err := model.GetUser(c.db, activistMergeData.MergedActivistName)
+	if err != nil {
+		sendErrorMessage(w, errors.Wrapf(err, "Could not fetch data for: %s", activistMergeData.MergedActivistName))
+		return
+	}
+
+	err = model.MergeUser(c.db, activistMergeData.CurrentActivistID, mergedUser.ID)
+	if err != nil {
+		sendErrorMessage(w, err)
+		return
+	}
+
+	out := map[string]interface{}{
+		"status": "success",
 	}
 	writeJSON(w, out)
 }

--- a/main.go
+++ b/main.go
@@ -383,7 +383,7 @@ func (c MainController) ActivistHideHandler(w http.ResponseWriter, r *http.Reque
 func (c MainController) ActivistMergeHandler(w http.ResponseWriter, r *http.Request) {
 	var activistMergeData struct {
 		CurrentActivistID  int    `json:"current_activist_id"`
-		MergedActivistName string `json:"merged_activist_name"`
+		TargetActivistName string `json:"target_activist_name"`
 	}
 	err := json.NewDecoder(r.Body).Decode(&activistMergeData)
 	if err != nil {
@@ -391,11 +391,11 @@ func (c MainController) ActivistMergeHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// First, we need to get the activist ID for the merged
+	// First, we need to get the activist ID for the target
 	// activist.
-	mergedUser, err := model.GetUser(c.db, activistMergeData.MergedActivistName)
+	mergedUser, err := model.GetUser(c.db, activistMergeData.TargetActivistName)
 	if err != nil {
-		sendErrorMessage(w, errors.Wrapf(err, "Could not fetch data for: %s", activistMergeData.MergedActivistName))
+		sendErrorMessage(w, errors.Wrapf(err, "Could not fetch data for: %s", activistMergeData.TargetActivistName))
 		return
 	}
 

--- a/model/db.go
+++ b/model/db.go
@@ -70,10 +70,10 @@ CREATE TABLE IF NOT EXISTS adb_users (
 	db.MustExec(`
 CREATE TABLE IF NOT EXISTS merged_activist_attendance (
   original_activist_id INTEGER NOT NULL,
-  merged_activist_id INTEGER NOT NULL,
+  target_activist_id INTEGER NOT NULL,
   event_id INTEGER NOT NULL,
-  replaced_with_merged_activist TINYINT(1) NOT NULL,
-  CONSTRAINT merged_activist_attendance_ukey UNIQUE (original_activist_id, merged_activist_id, event_id)
+  replaced_with_target_activist TINYINT(1) NOT NULL,
+  CONSTRAINT merged_activist_attendance_ukey UNIQUE (original_activist_id, target_activist_id, event_id)
 )
 `)
 }

--- a/model/db.go
+++ b/model/db.go
@@ -22,6 +22,7 @@ func WipeDatabase(db *sqlx.DB) {
 	db.MustExec(`DROP TABLE IF EXISTS events`)
 	db.MustExec(`DROP TABLE IF EXISTS event_attendance`)
 	db.MustExec(`DROP TABLE IF EXISTS adb_users`)
+	db.MustExec(`DROP TABLE IF EXISTS merged_activist_attendance`)
 
 	db.MustExec(`
 CREATE TABLE IF NOT EXISTS activists (
@@ -63,6 +64,16 @@ CREATE TABLE IF NOT EXISTS adb_users (
   email VARCHAR(60) NOT NULL,
   admin TINYINT(1) NOT NULL DEFAULT '0',
   disabled TINYINT(1) NOT NULL DEFAULT '0'
+)
+`)
+
+	db.MustExec(`
+CREATE TABLE IF NOT EXISTS merged_activist_attendance (
+  original_activist_id INTEGER NOT NULL,
+  merged_activist_id INTEGER NOT NULL,
+  event_id INTEGER NOT NULL,
+  replaced_with_merged_activist TINYINT(1) NOT NULL,
+  CONSTRAINT merged_activist_attendance_ukey UNIQUE (original_activist_id, merged_activist_id, event_id)
 )
 `)
 }


### PR DESCRIPTION
Add feature to merge one activist into another.

It works by hiding the activist you're merging and assigning all of their attendance to the "merged" user.

 - Add /activist/merge
 - Add `merged_activist_attendance` table so we can keep track of the merges that have been done so that they can be undone. The undo feature isn't implemented yet, we'll do that once we let people view hidden activists.

Some things I'd like feedback on:
 - Is there a better name than "mergedUserID" for the ID that we're merging into?
 - We don't have any checks that keep people from using the pre-merged user when taking attendance. Should we check that an activist hasn't been merged when we check attendance?