### PR TITLE
Add prompt for the developers email to `make dev_db`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ watch:
 # Wipe and re-create the dev databases. See the readme for more
 # details.
 dev_db:
-	go run ./scripts/create_db.go
+	./scripts/create_db_wrapper.sh
 
 # Install all deps for this project.
 deps:

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,2 @@
+# ignore the "scripts" binary
+scripts

--- a/scripts/create_db.go
+++ b/scripts/create_db.go
@@ -2,31 +2,33 @@ package main
 
 import (
 	"flag"
+	"fmt"
 
 	"github.com/dxe/adb/config"
 	"github.com/dxe/adb/model"
 )
 
 var noFakeData bool
+var devEmail string
 
 func init() {
-	noFake := flag.Bool("no-fake-data", false, "Don't pre-populate wihth data")
+	noFake := flag.Bool("no-fake-data", false, "Don't pre-populate with data")
+	devEmailPtr := flag.String("dev-email", "test-dev@directactioneverywhere.com", "The developer email used to login for local development")
 	flag.Parse()
+
 	noFakeData = *noFake
+	devEmail = *devEmailPtr
 }
 
 func createDevDB(name string) {
 	db := model.NewDB(config.DBUser + ":" + config.DBPassword + "@/" + name + "?multiStatements=true")
 	defer db.Close()
 	model.WipeDatabase(db)
-
-	if !noFakeData {
-		// Insert sample data
-		db.MustExec(`
+	insertStatement := fmt.Sprintf(`
 INSERT INTO activists
   (id, name, email, chapter, phone, location, facebook, activist_level, exclude_from_leaderboard, core_staff, global_team_member, liberation_pledge)
   VALUES
-  (1, 'Adam Kol', 'test@directactioneverywhere.com', 'SF Bay', '7035558484', 'Berkeley, United States', '', 'activist', 0, 0, 1, 1),
+  (1, 'Adam Kol', 'test@directactioneverywhere.com', 'Sf Bay', '7035558484', 'Berkeley, United States', '', 'activist', 0, 0, 1, 1),
   (2, 'Robin Houseman', 'testtest@gmail.com', 'SF Bay', '7035558484', 'United States','', 'activist', 0, 0, 0, 0),
   (3, 'aaa', 'test@comcast.net', 'SF Bay', '7035558484', 'Fairfield, United States', '', 'activist', 0, 0, 0, 0),
   (4, 'bbb', 'test@comcast.net', 'SF Bay', '7035558484', 'Fairfield, United States', '', 'activist', 0, 0, 0, 0),
@@ -58,8 +60,12 @@ INSERT INTO adb_users (id, email, admin, disabled) VALUES
   (2, 'cwbailey20042@gmail.com', 1, 0),
   (3, 'jakehobbs@gmail.com', 1, 0),
   (4, 'samer@directactioneverywhere.com', 1, 0),
-  (5, 'jake@directactioneverywhere.com', 1, 0);
-`)
+  (5, 'jake@directactioneverywhere.com', 1, 0),
+  (6, '%s', 1, 0);
+`, devEmail)
+	if !noFakeData {
+		// Insert sample data
+		db.MustExec(insertStatement)
 	}
 }
 

--- a/scripts/create_db_wrapper.sh
+++ b/scripts/create_db_wrapper.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+# if DXE_DEV_EMAIL is not set, prompt user for their email
+if [ -z ${DXE_DEV_EMAIL+x} ]; then
+    echo "Please enter your development email: "
+    read DXE_DEV_EMAIL
+fi
+go run ./scripts/create_db.go --dev-email="${DXE_DEV_EMAIL}"

--- a/scripts/create_db_wrapper.sh
+++ b/scripts/create_db_wrapper.sh
@@ -4,7 +4,7 @@ set -e
 
 # if DXE_DEV_EMAIL is not set, prompt user for their email
 if [ -z ${DXE_DEV_EMAIL+x} ]; then
-    echo "Please enter your development email: "
+    echo "Please enter your development email or set DXE_DEV_EMAIL to never see this message again: "
     read DXE_DEV_EMAIL
 fi
 go run ./scripts/create_db.go --dev-email="${DXE_DEV_EMAIL}"


### PR DESCRIPTION
When running `make dev_db`, the user is now prompted for their development email, and it is injected into `adb_db.adb_users` as an admin. Alternatively, the user can set the environment variable `DXE_DEV_EMAIL` in e.g. their `.bashrc` and never see the prompt.

I left the existing emails in the database creation script, though I can pull these out if you'd like to make this script a little cleaner =)