### PR TITLE
Sync "make dev_db" with production schema

### DIFF
--- a/model/db.go
+++ b/model/db.go
@@ -18,6 +18,7 @@ func WipeDatabase(db *sqlx.DB) {
 	if config.IsProd {
 		panic("Cannot drop tables in prod")
 	}
+
 	db.MustExec(`DROP TABLE IF EXISTS activists`)
 	db.MustExec(`DROP TABLE IF EXISTS events`)
 	db.MustExec(`DROP TABLE IF EXISTS event_attendance`)
@@ -25,59 +26,76 @@ func WipeDatabase(db *sqlx.DB) {
 	db.MustExec(`DROP TABLE IF EXISTS merged_activist_attendance`)
 	db.MustExec(`DROP TABLE IF EXISTS working_groups`)
 	db.MustExec(`DROP TABLE IF EXISTS working_group_members`)
+	db.MustExec(`DROP TABLE IF EXISTS circles`)
+	db.MustExec(`DROP TABLE IF EXISTS circle_members`)
 
 	db.MustExec(`
-CREATE TABLE IF NOT EXISTS activists (
+CREATE TABLE activists (
   id INTEGER PRIMARY KEY AUTO_INCREMENT,
   name VARCHAR(80) NOT NULL,
   email VARCHAR(80) NOT NULL DEFAULT '',
-  chapter VARCHAR(80) NOT NULL DEFAULT '',
-  phone varchar(20) NOT NULL DEFAULT '',
-  location TEXT,
-  facebook VARCHAR(80) NOT NULL DEFAULT '',
-  activist_level VARCHAR(40) NOT NULL DEFAULT 'activist',
-  exclude_from_leaderboard TINYINT(1) NOT NULL DEFAULT '0',
-  core_staff TINYINT(1) NOT NULL DEFAULT '0',
-  global_team_member TINYINT(1) NOT NULL DEFAULT '0',
-  liberation_pledge TINYINT(1) NOT NULL DEFAULT '0',
+  phone VARCHAR(20) NOT NULL DEFAULT '',
+  location VARCHAR(200) DEFAULT '',
+  facebook VARCHAR(200) NOT NULL DEFAULT '',
+  activist_level VARCHAR(40) NOT NULL DEFAULT 'Supporter',
   hidden TINYINT(1) NOT NULL DEFAULT '0',
   connector VARCHAR(100) NOT NULL DEFAULT '',
   contacted_date VARCHAR(20) NOT NULL DEFAULT '',
   interested VARCHAR(5) NOT NULL DEFAULT '',
   meeting_date VARCHAR(20) NOT NULL DEFAULT '',
   escalation VARCHAR(5) NOT NULL DEFAULT '',
-  core_training TINYINT(1) NOT NULL DEFAULT '0',
-  eligible_senior_organizer TINYINT(1) NOT NULL DEFAULT '0',
-  eligible_organizer TINYINT(1) NOT NULL DEFAULT '0',
   source VARCHAR(255) NOT NULL DEFAULT '',
-  interview_organizer VARCHAR(20) NOT NULL DEFAULT '',
-  interview_senior_organizer VARCHAR(20) NOT NULL DEFAULT '',
-  action_team_focus VARCHAR(40) NOT NULL DEFAULT '',
-  doing_work TINYINT(1) NOT NULL DEFAULT '0',
-  action_team_focus_secondary VARCHAR(255),
-
-  CONSTRAINT name_ukey UNIQUE (name)
-)`)
+  date_organizer DATE,
+  date_senior_organizer DATE,
+  dob TEXT,
+  training0 VARCHAR(20),
+  training1 VARCHAR(20),
+  training2 VARCHAR(20),
+  training3 VARCHAR(20),
+  training4 VARCHAR(20),
+  training5 VARCHAR(20),
+  training6 VARCHAR(20),
+  prospect_organizer TINYINT(1) NOT NULL DEFAULT '0',
+  prospect_chapter_member TINYINT NOT NULL DEFAULT '0',
+  prospect_circle_member TINYINT NOT NULL DEFAULT '0',
+  dev_manager VARCHAR(100) NOT NULL DEFAULT '',
+  dev_interest VARCHAR(200) NOT NULL DEFAULT '',
+  dev_auth VARCHAR(20),
+  dev_email_sent VARCHAR(20),
+  dev_vetted TINYINT(1) NOT NULL DEFAULT '0',
+  dev_interview VARCHAR(20),
+  dev_onboarding TINYINT(1) NOT NULL DEFAULT '0',
+  dev_application_date DATE,
+  cm_first_email VARCHAR(20),
+  cm_approval_email VARCHAR(20),
+  cm_warning_email VARCHAR(20),
+  cir_first_email VARCHAR(20),
+  UNIQUE (name)
+)
+`)
 
 	db.MustExec(`
-CREATE TABLE IF NOT EXISTS event_attendance (
+CREATE TABLE event_attendance (
   activist_id INTEGER NOT NULL,
   event_id INTEGER NOT NULL,
-  CONSTRAINT activist_event_ukey UNIQUE (activist_id, event_id),
-  CONSTRAINT event_activist_ukey UNIQUE (event_id, activist_id)
-)`)
+  UNIQUE (activist_id, event_id),
+  UNIQUE (event_id, activist_id)
+)
+`)
 
 	db.MustExec(`
-CREATE TABLE IF NOT EXISTS events (
+CREATE TABLE events (
   id INTEGER PRIMARY KEY AUTO_INCREMENT,
   name VARCHAR(60) NOT NULL,
   date DATE NOT NULL,
   event_type VARCHAR(60) NOT NULL,
-  FULLTEXT INDEX name_idx (name)
-)`)
+  INDEX (date, name),
+  FULLTEXT (name)
+)
+`)
 
 	db.MustExec(`
-CREATE TABLE IF NOT EXISTS adb_users (
+CREATE TABLE adb_users (
   id INTEGER PRIMARY KEY AUTO_INCREMENT,
   email VARCHAR(60) NOT NULL,
   admin TINYINT(1) NOT NULL DEFAULT '0',
@@ -86,27 +104,32 @@ CREATE TABLE IF NOT EXISTS adb_users (
 `)
 
 	db.MustExec(`
-CREATE TABLE IF NOT EXISTS merged_activist_attendance (
+CREATE TABLE merged_activist_attendance (
   original_activist_id INTEGER NOT NULL,
   target_activist_id INTEGER NOT NULL,
   event_id INTEGER NOT NULL,
   replaced_with_target_activist TINYINT(1) NOT NULL,
-  CONSTRAINT merged_activist_attendance_ukey UNIQUE (original_activist_id, target_activist_id, event_id)
+  UNIQUE (original_activist_id, target_activist_id, event_id)
 )
 `)
 
 	db.MustExec(`
-CREATE TABLE IF NOT EXISTS working_groups (
+CREATE TABLE working_groups (
   id INTEGER PRIMARY KEY AUTO_INCREMENT,
   name VARCHAR(60) NOT NULL,
   type TINYINT(1) NOT NULL,
   group_email VARCHAR(100) NOT NULL,
-  CONSTRAINT working_groups_name_ukey UNIQUE (name)
+  visible TINYINT(1) NOT NULL DEFAULT '0',
+  description TEXT NOT NULL,
+  meeting_time TEXT NOT NULL,
+  meeting_location TEXT NOT NULL,
+  coords TEXT NOT NULL,
+  UNIQUE (name)
 )
 `)
 
 	db.MustExec(`
-CREATE TABLE IF NOT EXISTS working_group_members (
+CREATE TABLE working_group_members (
   working_group_id INTEGER NOT NULL,
   activist_id INTEGER NOT NULL,
   -- True if the activist is the point person of the working group.
@@ -116,7 +139,34 @@ CREATE TABLE IF NOT EXISTS working_group_members (
   -- Some activists need to be on the mailing list even though they
   -- aren't in the workin group.
   non_member_on_mailing_list TINYINT NOT NULL DEFAULT '0',
-  CONSTRAINT working_group_member_ukey UNIQUE (working_group_id, activist_id)
+  UNIQUE (working_group_id, activist_id),
+  INDEX (activist_id)
+)
+`)
+
+	db.MustExec(`
+CREATE TABLE circles (
+  id INTEGER PRIMARY KEY AUTO_INCREMENT,
+  name VARCHAR(60) NOT NULL,
+  type TINYINT(1) NOT NULL,
+  group_email VARCHAR(100) NOT NULL DEFAULT '1',
+  visible TINYINT(1) NOT NULL DEFAULT '1',
+  description TEXT NOT NULL,
+  meeting_time TEXT NOT NULL,
+  meeting_location TEXT NOT NULL,
+  coords TEXT NOT NULL,
+  UNIQUE (name)
+)
+`)
+
+	db.MustExec(`
+CREATE TABLE circle_members (
+  circle_id INTEGER NOT NULL,
+  activist_id INTEGER NOT NULL,
+  point_person TINYINT NOT NULL DEFAULT '0',
+  non_member_on_mailing_list TINYINT NOT NULL DEFAULT '0',
+  UNIQUE (circle_id, activist_id),
+  INDEX (activist_id)
 )
 `)
 

--- a/scripts/create_db.go
+++ b/scripts/create_db.go
@@ -59,22 +59,22 @@ func createDevDB(name string) {
 	model.WipeDatabase(db)
 	insertStatement := fmt.Sprintf(`
 INSERT INTO activists
-  (id, name, email, chapter, phone, location, facebook, activist_level, exclude_from_leaderboard, core_staff, global_team_member, liberation_pledge)
+  (id, name, email, phone, location, activist_level)
   VALUES
-  (1, 'Adam Kol', 'test@directactioneverywhere.com', 'Sf Bay', '7035558484', 'Berkeley, United States', '', 'Community Member', 0, 0, 1, 1),
-  (2, 'Robin Houseman', 'testtest@gmail.com', 'SF Bay', '7035558484', 'United States','', 'Community Member', 0, 0, 0, 0),
-  (3, 'aaa', 'test@comcast.net', 'SF Bay', '7035558484', 'Fairfield, United States', '', 'Community Member', 0, 0, 0, 0),
-  (4, 'bbb', 'test@comcast.net', 'SF Bay', '7035558484', 'Fairfield, United States', '', 'Community Member', 0, 0, 0, 0),
-  (5, 'ccc', 'test@comcast.net', 'SF Bay', '7035558484', 'Fairfield, United States', '', 'Community Member', 0, 0, 0, 0),
-  (100, 'ddd', 'test.test.test@gmail.com', 'SF Bay', '', 'United States', '', 'Community Member', 0, 0, 0, 0),
-(101, 'eee', 'test.test.test@gmail.com', 'SF Bay', '', 'United States', '', 'Community Member', 0, 0, 0, 0),
-(102, 'fff', 'test.test.test@gmail.com', 'SF Bay', '', 'United States', '', 'Community Member', 0, 0, 0, 0),
-(103, 'ggg', 'test.test.test@gmail.com', 'SF Bay', '', 'United States', '', 'Community Member', 0, 0, 0, 0),
-(104, 'hhh', 'test.test.test@gmail.com', 'SF Bay', '', 'United States', '', 'Community Member', 0, 0, 0, 0),
-(105, 'iii', 'test.test.test@gmail.com', 'SF Bay', '', 'United States', '', 'Community Member', 0, 0, 0, 0),
-(106, 'jjj', 'test.test.test@gmail.com', 'SF Bay', '', 'United States', '', 'Community Member', 0, 0, 0, 0),
-(107, 'lll', 'test.test.test@gmail.com', 'SF Bay', '', 'United States', '', 'Community Member', 0, 0, 0, 0),
-  (108, 'mmm', 'test@gmail.com', 'SF Bay', '', 'United States', '', 'Community Member', 0, 0, 0, 0);
+  (1, 'Adam Kol', 'test@directactioneverywhere.com', '7035558484', 'Berkeley, United States', 'Community Member'),
+  (2, 'Robin Houseman', 'testtest@gmail.com', '7035558484', 'United States', 'Community Member'),
+  (3, 'aaa', 'test@comcast.net', '7035558484', 'Fairfield, United States', 'Community Member'),
+  (4, 'bbb', 'test@comcast.net', '7035558484', 'Fairfield, United States', 'Community Member'),
+  (5, 'ccc', 'test@comcast.net', '7035558484', 'Fairfield, United States', 'Community Member'),
+  (100, 'ddd', 'test.test.test@gmail.com', '', 'United States', 'Community Member'),
+  (101, 'eee', 'test.test.test@gmail.com', '', 'United States', 'Community Member'),
+  (102, 'fff', 'test.test.test@gmail.com', '', 'United States', 'Community Member'),
+  (103, 'ggg', 'test.test.test@gmail.com', '', 'United States', 'Community Member'),
+  (104, 'hhh', 'test.test.test@gmail.com', '', 'United States', 'Community Member'),
+  (105, 'iii', 'test.test.test@gmail.com', '', 'United States', 'Community Member'),
+  (106, 'jjj', 'test.test.test@gmail.com', '', 'United States', 'Community Member'),
+  (107, 'lll', 'test.test.test@gmail.com', '', 'United States', 'Community Member'),
+  (108, 'mmm', 'test@gmail.com', '', 'United States', 'Community Member');
 
 INSERT INTO events VALUES
   %s


### PR DESCRIPTION
"CREATE TABLE" queries were generated with MySQL's "SHOW CREATE TABLE"
command, and then cleaned up by hand (e.g., removing back quotes,
upper-casing type names, stripping unnecessary field attributes).

Also, simplified the UNIQUE constraints to be compatible with
PostgreSQL, and removed unnecessary index names.

Fixes #30.