### PR TITLE
Update npm dependencies (retry)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,5 @@
 {
     "presets": [
-        ["stage-2"],
-        ["es2015",  {"modules": false}]
+        ["@babel/preset-env"]
     ]
 }

--- a/package.json
+++ b/package.json
@@ -10,26 +10,24 @@
     "build": "NODE_ENV=production webpack --progress --hide-modules"
   },
   "dependencies": {
-    "babel-preset-env": "^1.6.0",
     "bootstrap-chosen": "^1.4.2",
     "chosen-js": "^1.7.0",
     "debounce": "^1.1.0",
-    "handsontable": "^0.34.5",
-    "uiv": "^0.11.8",
+    "handsontable": "^6.0.0",
+    "uiv": "^0.28.0",
     "vue": "^2.2.1",
-    "vue-infinite-loading": "^2.1.3",
     "vue-js-modal": "^1.1.1"
   },
   "devDependencies": {
-    "babel-core": "^6.0.0",
-    "babel-loader": "^6.0.0",
-    "babel-preset-latest": "^6.0.0",
-    "babel-preset-stage-2": "^6.24.1",
-    "css-loader": "^0.25.0",
-    "file-loader": "^0.9.0",
-    "style-loader": "^0.18.2",
-    "vue-loader": "^11.1.4",
+    "@babel/core": "^7.0.0",
+    "@babel/preset-env": "^7.2.3",
+    "babel-loader": "^8.0.0",
+    "css-loader": "^2.0.0",
+    "file-loader": "^3.0.0",
+    "style-loader": "^0.23.0",
+    "vue-loader": "^15.0.0",
     "vue-template-compiler": "^2.2.1",
-    "webpack": "^2.2.0"
+    "webpack": "^4.0.0",
+    "webpack-cli": "^3.1.2"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,9 @@
 var path = require('path')
 var webpack = require('webpack')
+var VueLoaderPlugin = require('vue-loader/lib/plugin')
 
 module.exports = {
+  mode: 'development',
 
   // List of bundles to create. If you want to add a new page, you'll
   // need to also add it here.
@@ -21,6 +23,10 @@ module.exports = {
     library: '[name]',
     libraryTarget: 'var',
   },
+
+  plugins: [
+    new VueLoaderPlugin(),
+  ],
 
   module: {
     rules: [
@@ -70,22 +76,5 @@ module.exports = {
 }
 
 if (process.env.NODE_ENV === 'production') {
-  module.exports.devtool = '#source-map'
-  // http://vue-loader.vuejs.org/en/workflow/production.html
-  module.exports.plugins = (module.exports.plugins || []).concat([
-    new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: '"production"'
-      }
-    }),
-    new webpack.optimize.UglifyJsPlugin({
-      sourceMap: true,
-      compress: {
-        warnings: false
-      }
-    }),
-    new webpack.LoaderOptionsPlugin({
-      minimize: true
-    })
-  ])
+  module.exports.mode = 'production';
 }


### PR DESCRIPTION
Two notable changes:

1. webpack now natively support development and production build "modes",
which obviates the need for manually configuring additional minimization
plugins in production mode. So our webpack.config.js file simplifies a bit.
(Exception: vue-loader now requires a webpack plugin.)

2. babel config now automatically detects which modern JavaScript constructs
need to be transpiled to support legacy browsers.

While here, remove unused vue-infinite-loading dependency.

Fixes #33.