### PR TITLE
Convert Vue components to class-style

### DIFF
--- a/frontend/CirclesList.vue
+++ b/frontend/CirclesList.vue
@@ -266,7 +266,7 @@
 
 <script lang="ts">
 import vmodal from 'vue-js-modal';
-import Vue from 'vue';
+import { Vue, Component } from 'vue-property-decorator';
 import { flashMessage } from './flash_message';
 import { Dropdown } from 'uiv';
 import { initActivistSelect } from './chosen_utils';
@@ -287,221 +287,238 @@ interface Circle {
   members: Activist[];
 }
 
-export default Vue.extend({
-  name: 'circle-list',
-  methods: {
-    showModal(modalName: string, circleGroup: Circle, index: number) {
-      // Check to see if there's a modal open, and close it if so.
-      if (this.currentModalName) {
-        this.hideModal();
-      }
+@Component({
+  components: {
+    Dropdown,
+    BasicSelect,
+  },
+  directives: {
+    focus,
+  },
+})
+export default class CirclesList extends Vue {
+  showModal(modalName: string, circleGroup: Circle, index: number) {
+    // Check to see if there's a modal open, and close it if so.
+    if (this.currentModalName) {
+      this.hideModal();
+    }
 
-      this.currentCircleGroup = { ...circleGroup };
+    this.currentCircleGroup = { ...circleGroup };
 
-      if (index != undefined) {
-        this.circleGroupIndex = index;
-      } else {
-        this.circleGroupIndex = -1;
-      }
-
-      this.currentModalName = modalName;
-      this.$modal.show(modalName);
-    },
-    hideModal() {
-      if (this.currentModalName) {
-        this.$modal.hide(this.currentModalName);
-      }
-      this.currentModalName = '';
+    if (index != undefined) {
+      this.circleGroupIndex = index;
+    } else {
       this.circleGroupIndex = -1;
-      this.currentCircleGroup = {} as Circle;
+    }
 
-      // Sort cirlce group list
-      this.sortListByName();
-    },
-    sortListByName() {
-      if (!this.circleGroups) {
-        return;
-      }
+    this.currentModalName = modalName;
+    this.$modal.show(modalName);
+  }
 
-      this.circleGroups.sort((a, b) => {
-        let nameA = a.name.toLowerCase();
-        let nameB = b.name.toLowerCase();
+  hideModal() {
+    if (this.currentModalName) {
+      this.$modal.hide(this.currentModalName);
+    }
+    this.currentModalName = '';
+    this.circleGroupIndex = -1;
+    this.currentCircleGroup = {} as Circle;
 
-        return nameA < nameB ? -1 : nameA > nameB ? 1 : 0;
-      });
-    },
-    confirmEditCircleGroupModal() {
-      // First, check for duplicate activists because that's the most
-      // likely error.
-      if (this.currentCircleGroup.members) {
-        var members = this.currentCircleGroup.members;
-        var memberNameMap = new Set<string>();
-        for (var i = 0; i < members.length; i++) {
-          if (members[i].name in memberNameMap) {
-            flashMessage('Error: Cannot have duplicate members: ' + members[i].name, true);
-            return;
-          }
-          memberNameMap.add(members[i].name);
-        }
-      }
+    // Sort cirlce group list
+    this.sortListByName();
+  }
 
-      // Save working group
-      this.disableConfirmButton = true;
+  sortListByName() {
+    if (!this.circleGroups) {
+      return;
+    }
 
-      $.ajax({
-        url: '/circle/save',
-        method: 'POST',
-        contentType: 'application/json',
-        data: JSON.stringify(this.currentCircleGroup),
-        success: (data) => {
-          this.disableConfirmButton = false;
+    this.circleGroups.sort((a, b) => {
+      let nameA = a.name.toLowerCase();
+      let nameB = b.name.toLowerCase();
 
-          var parsed = JSON.parse(data);
-          if (parsed.status === 'error') {
-            flashMessage('Error: ' + parsed.message, true);
-            return;
-          }
-          // status === "success"
-          flashMessage(this.currentCircleGroup.name + ' saved');
+      return nameA < nameB ? -1 : nameA > nameB ? 1 : 0;
+    });
+  }
 
-          if (this.circleGroupIndex === -1) {
-            // New working group, insert at the top
-            this.circleGroups = [parsed.circle].concat(this.circleGroups);
-          } else {
-            // We edited an existing circle, replace their row.
-            Vue.set(this.circleGroups, this.circleGroupIndex, parsed.circle);
-          }
-
-          this.hideModal();
-        },
-        error: (err) => {
-          this.disableConfirmButton = false;
-          console.warn(err.responseText);
-          flashMessage('Server error: ' + err.responseText, true);
-        },
-      });
-    },
-    confirmDeleteCircleGroupModal() {
-      this.disableConfirmButton = true;
-
-      $.ajax({
-        url: '/circle/delete',
-        method: 'POST',
-        contentType: 'application/json',
-        data: JSON.stringify({
-          circle_id: this.currentCircleGroup.id,
-        }),
-        success: (data) => {
-          this.disableConfirmButton = false;
-
-          var parsed = JSON.parse(data);
-          if (parsed.status === 'error') {
-            flashMessage('Error: ' + parsed.message, true);
-            return;
-          }
-          // status === "success"
-          flashMessage(this.currentCircleGroup.name + ' deleted');
-          this.circleGroups.splice(this.circleGroupIndex, this.circleGroupIndex + 1);
-          this.hideModal();
-        },
-        error: (err) => {
-          this.disableConfirmButton = false;
-          console.warn(err.responseText);
-          flashMessage('Server error: ' + err.responseText, true);
-        },
-      });
-    },
-    modalOpened() {
-      $(document.body).addClass('noscroll');
-      this.disableConfirmButton = false;
-    },
-    modalClosed() {
-      $(document.body).removeClass('noscroll');
-    },
-    displaycircleGroupType(type: string) {
-      switch (type) {
-        case 'circle':
-          return 'Circle';
-      }
-      return '';
-    },
-    addMember() {
-      if (this.currentCircleGroup.members === undefined) {
-        Vue.set(this.currentCircleGroup, 'members', []);
-      }
-      this.currentCircleGroup.members.push({ name: '' });
-    },
-    addPointPerson() {
-      if (this.currentCircleGroup.members === undefined) {
-        Vue.set(this.currentCircleGroup, 'members', []);
-      }
-      this.currentCircleGroup.members.push({ name: '', point_person: true });
-    },
-    addNonMember() {
-      if (this.currentCircleGroup.members === undefined) {
-        Vue.set(this.currentCircleGroup, 'members', []);
-      }
-      this.currentCircleGroup.members.push({ name: '', non_member_on_mailing_list: true });
-    },
-    removeMember(index: number) {
-      this.currentCircleGroup.members.splice(index, 1);
-    },
-    memberOption(member: Circle) {
-      return { text: member.name };
-    },
-    onMemberSelect(selected: any, extraData: any) {
-      var index = extraData.index;
-      Vue.set(this.currentCircleGroup.members, index, {
-        name: selected.text,
-        point_person: !!extraData.pointPerson,
-        non_member_on_mailing_list: !!extraData.nonMemberOnMailingList,
-      });
-    },
-    numberOfCircleGroupMembers(circleGroup: Circle) {
-      if (!circleGroup.members) {
-        return 0;
-      }
-
-      var count = 0;
-      for (var i = 0; i < circleGroup.members.length; i++) {
-        if (!circleGroup.members[i].non_member_on_mailing_list) {
-          count++;
-        }
-      }
-
-      return count;
-    },
-  },
-  data() {
-    return {
-      currentCircleGroup: {} as Circle,
-      circleGroups: [] as Circle[],
-      circleGroupIndex: -1,
-      disableConfirmButton: false,
-      currentModalName: '',
-      activistOptions: [],
-    };
-  },
-  computed: {
-    showAddPointPerson() {
-      if (!this.currentCircleGroup) {
-        return false; // doesn't matter
-      }
-      if (this.currentCircleGroup && !this.currentCircleGroup.members) {
-        return true;
-      }
-
+  confirmEditCircleGroupModal() {
+    // First, check for duplicate activists because that's the most
+    // likely error.
+    if (this.currentCircleGroup.members) {
       var members = this.currentCircleGroup.members;
-      var numPointPeople = 0;
+      var memberNameMap = new Set<string>();
       for (var i = 0; i < members.length; i++) {
-        if (members[i].point_person) {
-          numPointPeople++;
+        if (members[i].name in memberNameMap) {
+          flashMessage('Error: Cannot have duplicate members: ' + members[i].name, true);
+          return;
         }
+        memberNameMap.add(members[i].name);
       }
+    }
 
-      return numPointPeople < 1;
-    },
-  },
+    // Save working group
+    this.disableConfirmButton = true;
+
+    $.ajax({
+      url: '/circle/save',
+      method: 'POST',
+      contentType: 'application/json',
+      data: JSON.stringify(this.currentCircleGroup),
+      success: (data) => {
+        this.disableConfirmButton = false;
+
+        var parsed = JSON.parse(data);
+        if (parsed.status === 'error') {
+          flashMessage('Error: ' + parsed.message, true);
+          return;
+        }
+        // status === "success"
+        flashMessage(this.currentCircleGroup.name + ' saved');
+
+        if (this.circleGroupIndex === -1) {
+          // New working group, insert at the top
+          this.circleGroups = [parsed.circle].concat(this.circleGroups);
+        } else {
+          // We edited an existing circle, replace their row.
+          Vue.set(this.circleGroups, this.circleGroupIndex, parsed.circle);
+        }
+
+        this.hideModal();
+      },
+      error: (err) => {
+        this.disableConfirmButton = false;
+        console.warn(err.responseText);
+        flashMessage('Server error: ' + err.responseText, true);
+      },
+    });
+  }
+
+  confirmDeleteCircleGroupModal() {
+    this.disableConfirmButton = true;
+
+    $.ajax({
+      url: '/circle/delete',
+      method: 'POST',
+      contentType: 'application/json',
+      data: JSON.stringify({
+        circle_id: this.currentCircleGroup.id,
+      }),
+      success: (data) => {
+        this.disableConfirmButton = false;
+
+        var parsed = JSON.parse(data);
+        if (parsed.status === 'error') {
+          flashMessage('Error: ' + parsed.message, true);
+          return;
+        }
+        // status === "success"
+        flashMessage(this.currentCircleGroup.name + ' deleted');
+        this.circleGroups.splice(this.circleGroupIndex, this.circleGroupIndex + 1);
+        this.hideModal();
+      },
+      error: (err) => {
+        this.disableConfirmButton = false;
+        console.warn(err.responseText);
+        flashMessage('Server error: ' + err.responseText, true);
+      },
+    });
+  }
+
+  modalOpened() {
+    $(document.body).addClass('noscroll');
+    this.disableConfirmButton = false;
+  }
+
+  modalClosed() {
+    $(document.body).removeClass('noscroll');
+  }
+
+  displaycircleGroupType(type: string) {
+    switch (type) {
+      case 'circle':
+        return 'Circle';
+    }
+    return '';
+  }
+
+  addMember() {
+    if (this.currentCircleGroup.members === undefined) {
+      Vue.set(this.currentCircleGroup, 'members', []);
+    }
+    this.currentCircleGroup.members.push({ name: '' });
+  }
+
+  addPointPerson() {
+    if (this.currentCircleGroup.members === undefined) {
+      Vue.set(this.currentCircleGroup, 'members', []);
+    }
+    this.currentCircleGroup.members.push({ name: '', point_person: true });
+  }
+
+  addNonMember() {
+    if (this.currentCircleGroup.members === undefined) {
+      Vue.set(this.currentCircleGroup, 'members', []);
+    }
+    this.currentCircleGroup.members.push({ name: '', non_member_on_mailing_list: true });
+  }
+
+  removeMember(index: number) {
+    this.currentCircleGroup.members.splice(index, 1);
+  }
+
+  memberOption(member: Circle) {
+    return { text: member.name };
+  }
+
+  onMemberSelect(selected: any, extraData: any) {
+    var index = extraData.index;
+    Vue.set(this.currentCircleGroup.members, index, {
+      name: selected.text,
+      point_person: !!extraData.pointPerson,
+      non_member_on_mailing_list: !!extraData.nonMemberOnMailingList,
+    });
+  }
+
+  numberOfCircleGroupMembers(circleGroup: Circle) {
+    if (!circleGroup.members) {
+      return 0;
+    }
+
+    var count = 0;
+    for (var i = 0; i < circleGroup.members.length; i++) {
+      if (!circleGroup.members[i].non_member_on_mailing_list) {
+        count++;
+      }
+    }
+
+    return count;
+  }
+
+  currentCircleGroup = {} as Circle;
+  circleGroups = [] as Circle[];
+  circleGroupIndex = -1;
+  disableConfirmButton = false;
+  currentModalName = '';
+  activistOptions = [];
+
+  get showAddPointPerson() {
+    if (!this.currentCircleGroup) {
+      return false; // doesn't matter
+    }
+    if (this.currentCircleGroup && !this.currentCircleGroup.members) {
+      return true;
+    }
+
+    var members = this.currentCircleGroup.members;
+    var numPointPeople = 0;
+    for (var i = 0; i < members.length; i++) {
+      if (members[i].point_person) {
+        numPointPeople++;
+      }
+    }
+
+    return numPointPeople < 1;
+  }
+
   created() {
     // Get circles
     $.ajax({
@@ -537,15 +554,8 @@ export default Vue.extend({
         flashMessage('Server error: ' + err.responseText, true);
       },
     });
-  },
-  components: {
-    Dropdown,
-    BasicSelect,
-  },
-  directives: {
-    focus,
-  },
-});
+  }
+}
 </script>
 
 <style>

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "handsontable": "^6.0.0",
     "uiv": "^0.28.0",
     "vue": "^2.5.21",
-    "vue-js-modal": "^1.1.1"
+    "vue-js-modal": "^1.1.1",
+    "vue-property-decorator": "^7.2.0"
   },
   "devDependencies": {
     "@types/awesomplete": "^1.1.8",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "strict": true,
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
     "types": ["jquery"],
   },
   "include": [


### PR DESCRIPTION
The diff looks large, but it's mostly mechanical: instead of

    export default {
      data() {
        return {
          x: 42,
          y: "quux",
        };
      },
      created() { ... },
      methods: {
        foo() { ... },
        bar() { ... },
      },
    };

we can now write components as (almost) normal TypeScript classes:

    @Component
    export default class MyComponent extends Vue {
      x = 42;
      y = "quux";

      created() { ... }
      foo() { ... }
      bar() { ... }
    }

There are a couple minor gotchas to be aware of, but they're reasonably documented:

https://vuejs.org/v2/guide/typescript.html#Class-Style-Vue-Components
https://github.com/vuejs/vue-class-component
