### PR TITLE
remove unused CSS class names

### DIFF
--- a/frontend/ActivistList.vue
+++ b/frontend/ActivistList.vue
@@ -1,5 +1,5 @@
 <template>
-  <adb-page :title="title" :description="description" wide class="activist-list-content">
+  <adb-page :title="title" :description="description" wide>
     <div class="activist-list-filters form-inline">
       <input
         v-on:input="debounceSearchInput"

--- a/frontend/CirclesList.vue
+++ b/frontend/CirclesList.vue
@@ -1,5 +1,5 @@
 <template>
-  <adb-page title="Circles" class="body-circles-list-content">
+  <adb-page title="Circles">
     <button class="btn btn-default" @click="showModal('edit-circle-modal')">
       <span class="glyphicon glyphicon-plus"></span>&nbsp;&nbsp;Add New Circle
     </button>

--- a/frontend/EventList.vue
+++ b/frontend/EventList.vue
@@ -1,8 +1,5 @@
 <template>
-  <adb-page
-    :title="connections ? 'All Maintenance Connections' : 'Events'"
-    class="event-list-content"
-  >
+  <adb-page :title="connections ? 'All Maintenance Connections' : 'Events'">
     <form class="form-inline hidden-xs" v-on:submit.prevent="eventListRequest">
       <label for="event-name">{{ connections ? 'Connector' : 'Event Name' }}:</label>
       <input
@@ -125,13 +122,13 @@
               Attendance: {{ event.attendees.length }}
             </span>
           </td>
-          <td class="event-name">
+          <td>
             <b>{{ event.event_name }}</b>
           </td>
           <td nowrap class="hidden-xs">{{ event.event_type }}</td>
           <td nowrap class="hidden-xs">{{ event.attendees.length }}</td>
           <td class="hidden-xs">
-            <button class="show-attendees btn btn-link" v-on:click="toggleAttendees(event)">
+            <button class="btn btn-link" v-on:click="toggleAttendees(event)">
               <span v-if="event.showAttendees">-</span> <span v-else>+</span> Attendees
             </button>
             <a target="_blank" class="btn btn-link" :href="event.emailLink">

--- a/frontend/UserList.vue
+++ b/frontend/UserList.vue
@@ -1,9 +1,9 @@
 <template>
-  <adb-page title="Users" class="activist-list-content">
+  <adb-page title="Users">
     <button class="btn btn-default" @click="showModal('edit-user-modal')">
       <span class="glyphicon glyphicon-plus"></span>&nbsp;&nbsp;Add New User
     </button>
-    <table id="user-list" class="adb-table table table-hover table-striped tablesorter">
+    <table id="user-list" class="adb-table table table-hover table-striped">
       <thead>
         <tr>
           <th></th>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -126,9 +126,6 @@ a.logout-link:hover, a.logout-link:active {
 }
 
 /* event_list */
-.event-list-content {
-        /*min-width: 600px;*/
-}
 .attendee-list {
     padding-left: 15px;
     list-style-position: outside;

--- a/templates/403.html
+++ b/templates/403.html
@@ -2,7 +2,7 @@
 <meta name="google-signin-client_id" content="975059814880-lfffftbpt7fdl14cevtve8sjvh015udc.apps.googleusercontent.com">
 <script src="https://apis.google.com/js/platform.js" async defer></script>
 
-<div class="body-wrapper login-content">
+<div class="body-wrapper">
   <p>Access Forbidden</p>
   <div>You do not have permission to view the requested resource.</div>
 </div>

--- a/templates/header.html
+++ b/templates/header.html
@@ -19,7 +19,7 @@
 
     <script src="/dist/flash_message.js"></script>
   </head>
-  <body class="{{if (eq .PageName "ActivistList")}}activist-list-body{{end}}">
+  <body>
     <div id="flash" role="alert"></div>
     <script>flash_message.initializeFlashMessage();</script>
     <nav class="navbar navbar-inverse navbar-fixed-top">

--- a/templates/login.html
+++ b/templates/login.html
@@ -2,7 +2,7 @@
 <meta name="google-signin-client_id" content="975059814880-lfffftbpt7fdl14cevtve8sjvh015udc.apps.googleusercontent.com">
 <script src="https://apis.google.com/js/platform.js" async defer></script>
 
-<div class="body-wrapper login-content">
+<div class="body-wrapper">
   <p>Please log in.</p>
   <div id="message"></div>
   <div class="g-signin2" data-onsuccess="onSignIn"></div>

--- a/templates/logout.html
+++ b/templates/logout.html
@@ -2,7 +2,7 @@
 <meta name="google-signin-client_id" content="975059814880-lfffftbpt7fdl14cevtve8sjvh015udc.apps.googleusercontent.com">
 <script src="https://apis.google.com/js/platform.js?onload=onLoad" async defer></script>
 
-<div class="body-wrapper login-content">
+<div class="body-wrapper">
   <script>
     function onLoad() {
       gapi.load('auth2', function () {


### PR DESCRIPTION
For each removed CSS class name "foo", I couldn't find ".foo" anywhere
in a CSS source file.