### PR TITLE
integrate surveys into adb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN GOFLAGS=-mod=readonly GOPROXY=https://proxy.golang.org go mod download
 COPY main.go ./
 COPY config config/
 COPY mailinglist_sync mailinglist_sync/
+COPY survey_mailer survey_mailer/
 COPY model model/
 RUN CGO_ENABLED=0 go build -o adb
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ CREATE DATABASE adb_test_db CHARACTER SET utf8 COLLATE utf8_general_ci;
 
 Then run `make dev_db`.
 
+### Environment variables required for surveys to be sent
+- AWS_ACCESS_KEY_ID
+- AWS_SECRET_KEY
+- AWS_SES_ENDPOINT (example: https://email.us-west-2.amazonaws.com)
+- SURVEY_FROM_EMAIL (address surveys should be sent from)
+- SURVEY_MISSING_EMAIL (address to alert is survey recipients are missing email address)
+
 ## JS
 
 This project uses webpack to compile our frontend files. Frontend

--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,13 @@ var (
 	// The email for the user that that the oauth account should
 	// take action as.
 	SyncMailingListsOauthSubject = mustGetenv("SYNC_MAILING_LISTS_OAUTH_SUBJECT", "")
+
+	// For sending surveys
+	AWSAccessKey       = mustGetenv("AWS_ACCESS_KEY_ID", "")
+	AWSSecretKey       = mustGetenv("AWS_SECRET_KEY", "")
+	AWSSESEndpoint     = mustGetenv("AWS_SES_ENDPOINT", "")
+	SurveyMissingEmail = mustGetenv("SURVEY_MISSING_EMAIL", "")
+	SurveyFromEmail    = mustGetenv("SURVEY_FROM_EMAIL", "")
 )
 
 func mustGetenv(key, fallback string) string {

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/justinas/alice v1.2.0
 	github.com/pkg/errors v0.8.1
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
+	github.com/sourcegraph/go-ses v0.0.0-20160405160939-6bd8d17cf7c1
 	github.com/stretchr/testify v1.4.0
 	github.com/urfave/negroni v1.0.0
 	go.opencensus.io v0.22.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -181,6 +181,8 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/sourcegraph/go-ses v0.0.0-20160405160939-6bd8d17cf7c1 h1:2Ndulo7XO8FH6BqX62+FG9Hvl1uOBwDSrE6BAkTNHtA=
+github.com/sourcegraph/go-ses v0.0.0-20160405160939-6bd8d17cf7c1/go.mod h1:7pQ21TK+WkdBIwDfMovYhmNyGeBduRj3S089GgpNQ3g=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dxe/adb/config"
 	"github.com/dxe/adb/mailinglist_sync"
 	"github.com/dxe/adb/model"
+	"github.com/dxe/adb/survey_mailer"
 	"github.com/getsentry/sentry-go"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
@@ -1302,6 +1303,12 @@ func main() {
 	// the environment set up.
 	if config.SyncMailingListsConfigFile != "" {
 		go mailinglist_sync.StartMailingListsSync(db)
+	}
+
+	// Start running survey mailer in the background if we have
+	// the environment set up.
+	if config.SurveyMissingEmail != "" && config.SurveyFromEmail != "" && config.AWSAccessKey != "" && config.AWSSecretKey != "" && config.AWSSESEndpoint != "" {
+		go survey_mailer.StartSurveyMailer(db)
 	}
 
 	// Set up server

--- a/model/db.go
+++ b/model/db.go
@@ -109,6 +109,7 @@ CREATE TABLE events (
   name VARCHAR(60) NOT NULL,
   date DATE NOT NULL,
   event_type VARCHAR(60) NOT NULL,
+  survey_sent TINYINT(1) NOT NULL DEFAULT '0',
   INDEX (date, name),
   FULLTEXT (name)
 )

--- a/model/event.go
+++ b/model/event.go
@@ -46,14 +46,16 @@ type EventJSON struct {
 
 /* TODO Restructure this Struct */
 type Event struct {
-	ID               int       `db:"id"`
-	EventName        string    `db:"name"`
-	EventDate        time.Time `db:"date"`
-	EventType        EventType `db:"event_type"`
-	Attendees        []string  // For retrieving all event attendees
-	AttendeeEmails   []string
-	AddedAttendees   []Activist // Used for Updating Events
-	DeletedAttendees []Activist // Used for Updating Events
+	ID                    int       `db:"id"`
+	EventName             string    `db:"name"`
+	EventDate             time.Time `db:"date"`
+	EventType             EventType `db:"event_type"`
+	SurveySent            int       `db:"survey_sent"` // Used for sending event surveys
+	Attendees             []string  // For retrieving all event attendees
+	AttendeeEmails        []string
+	AttendeeMissingEmails []string   // Used for sending event surveys
+	AddedAttendees        []Activist // Used for Updating Events
+	DeletedAttendees      []Activist // Used for Updating Events
 }
 
 func (event *Event) ToJSON() EventJSON {
@@ -77,6 +79,7 @@ type GetEventOptions struct {
 	EventType      string
 	EventNameQuery string
 	EventActivist  string
+	SurveySent     string
 }
 
 /** Functions and Methods */
@@ -116,7 +119,7 @@ func GetEvent(db *sqlx.DB, options GetEventOptions) (Event, error) {
 
 func getEvents(db *sqlx.DB, options GetEventOptions) ([]Event, error) {
 	var queryArgs []interface{}
-	query := `SELECT e.id, e.name, e.date, e.event_type FROM events e `
+	query := `SELECT e.id, e.name, e.date, e.event_type, e.survey_sent FROM events e `
 
 	// Items in whereClause are added to the query in order, separated by ' AND '.
 	var whereClause []string
@@ -145,6 +148,10 @@ ON (e.id = ea.event_id AND ea.activist_id = a.id)
 		whereClause = append(whereClause, "e.date <= ?")
 		queryArgs = append(queryArgs, options.DateTo)
 	}
+	if options.SurveySent != "" {
+		whereClause = append(whereClause, "e.survey_sent = ?")
+		queryArgs = append(queryArgs, options.SurveySent)
+	}
 	if options.EventType == "noConnections" {
 		whereClause = append(whereClause, "e.event_type <> 'Connection'")
 	} else if options.EventType == "mpiDA" {
@@ -152,7 +159,7 @@ ON (e.id = ea.event_id AND ea.activist_id = a.id)
 	} else if options.EventType == "mpiCOM" {
 		whereClause = append(whereClause, "(e.event_type = 'Community' or e.event_type = 'Training' or e.event_type = 'Circle')")
 	} else if options.EventType != "" {
-		whereClause = append(whereClause, "e.event_type = ?")
+		whereClause = append(whereClause, "e.event_type like ?")
 		queryArgs = append(queryArgs, options.EventType)
 	}
 	if options.EventNameQuery != "" {
@@ -219,7 +226,11 @@ WHERE
 	for _, a := range allAttendance {
 		i := eventIDToIndex[a.EventID]
 		events[i].Attendees = append(events[i].Attendees, a.ActivistName)
-		events[i].AttendeeEmails = append(events[i].AttendeeEmails, a.ActivistEmail)
+		if a.ActivistEmail != "" {
+			events[i].AttendeeEmails = append(events[i].AttendeeEmails, a.ActivistEmail)
+		} else {
+			events[i].AttendeeMissingEmails = append(events[i].AttendeeMissingEmails, a.ActivistName)
+		}
 	}
 
 	return events, nil
@@ -355,6 +366,41 @@ WHERE
 		tx.Rollback()
 		return 0, errors.Wrap(err, "failed to insert event attendance")
 	}
+	if err := tx.Commit(); err != nil {
+		tx.Rollback()
+		return 0, errors.Wrap(err, "failed to commit update event")
+	}
+	return event.ID, nil
+}
+
+func UpdateEventSurveyStatus(db *sqlx.DB, event Event) (eventID int, err error) {
+	tx, err := db.Beginx()
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to update event")
+	}
+	// Error out if the event doesn't exist.
+	var eventCount int
+	err = tx.Get(&eventCount, `SELECT count(*) FROM events WHERE id = ?`, event.ID)
+	if err != nil {
+		tx.Rollback()
+		return 0, errors.Wrap(err, "failed to get event count")
+	}
+	if eventCount == 0 {
+		tx.Rollback()
+		return 0, errors.Errorf("Event with id %d does not exist", event.ID)
+	}
+
+	// Update the event
+	_, err = tx.NamedExec(`UPDATE events
+SET
+  survey_sent = :survey_sent
+WHERE
+  id = :id`, event)
+	if err != nil {
+		tx.Rollback()
+		return 0, errors.Wrap(err, "failed to update event")
+	}
+
 	if err := tx.Commit(); err != nil {
 		tx.Rollback()
 		return 0, errors.Wrap(err, "failed to commit update event")

--- a/model/event.go
+++ b/model/event.go
@@ -378,17 +378,6 @@ func UpdateEventSurveyStatus(db *sqlx.DB, event Event) (eventID int, err error) 
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to update event")
 	}
-	// Error out if the event doesn't exist.
-	var eventCount int
-	err = tx.Get(&eventCount, `SELECT count(*) FROM events WHERE id = ?`, event.ID)
-	if err != nil {
-		tx.Rollback()
-		return 0, errors.Wrap(err, "failed to get event count")
-	}
-	if eventCount == 0 {
-		tx.Rollback()
-		return 0, errors.Errorf("Event with id %d does not exist", event.ID)
-	}
 
 	// Update the event
 	_, err = tx.NamedExec(`UPDATE events

--- a/model/event.go
+++ b/model/event.go
@@ -226,11 +226,7 @@ WHERE
 	for _, a := range allAttendance {
 		i := eventIDToIndex[a.EventID]
 		events[i].Attendees = append(events[i].Attendees, a.ActivistName)
-		if a.ActivistEmail != "" {
-			events[i].AttendeeEmails = append(events[i].AttendeeEmails, a.ActivistEmail)
-		} else {
-			events[i].AttendeeMissingEmails = append(events[i].AttendeeMissingEmails, a.ActivistName)
-		}
+		events[i].AttendeeEmails = append(events[i].AttendeeEmails, a.ActivistEmail)
 	}
 
 	return events, nil

--- a/scripts/create_db.go
+++ b/scripts/create_db.go
@@ -33,12 +33,12 @@ func createCurrentDateString(day int) string {
 func createEventsDevDB() string {
 	days := []int{15, 16, 17, 18, 19, 13}
 	eventFormatStrings := []string{
-		"(1, 'Event One', '%s', 'Working Group'),",
-		"(2, 'Event Two', '%s', 'Protest'),",
-		"(3, 'Event Three', '%s', 'Community'),",
-		"(4, 'Event Four', '%s', 'Outreach'),",
-		"(5, 'Event Five', '%s', 'Key Event'),",
-		"(6, 'Event Six', '%s', 'Key Event');"}
+		"(1, 'Event One', '%s', 'Working Group', '0'),",
+		"(2, 'Event Two', '%s', 'Protest', '0'),",
+		"(3, 'Event Three', '%s', 'Community', '0'),",
+		"(4, 'Event Four', '%s', 'Outreach', '0'),",
+		"(5, 'Event Five', '%s', 'Key Event', '0'),",
+		"(6, 'Event Six', '%s', 'Key Event', '0');"}
 
 	//assert
 	if len(days) != len(eventFormatStrings) {
@@ -64,7 +64,7 @@ INSERT INTO activists
   (1, 'Adam Kol', 'test@directactioneverywhere.com', '7035558484', 'Berkeley, United States', 'Supporter'),
   (2, 'Robin Houseman', 'testtest@gmail.com', '7035558484', 'United States', 'Supporter'),
   (3, 'aaa', 'test@comcast.net', '7035558484', 'Fairfield, United States', 'Supporter'),
-  (4, 'bbb', 'test@comcast.net', '7035558484', 'Fairfield, United States', 'Supporter'),
+  (4, 'bbb', '', '7035558484', 'Fairfield, United States', 'Supporter'),
   (5, 'ccc', 'test@comcast.net', '7035558484', 'Fairfield, United States', 'Supporter'),
   (100, 'ddd', 'test.test.test@gmail.com', '', 'United States', 'Supporter'),
   (101, 'eee', 'test.test.test@gmail.com', '', 'United States', 'Supporter'),

--- a/survey_mailer/survey_mailer.go
+++ b/survey_mailer/survey_mailer.go
@@ -29,10 +29,10 @@ func sendMissingEmail(eventName string, attendees []string, sendingErrors []stri
 	bodyHtml := ""
 
 	if len(attendees) > 0 {
-		bodyText += "The following people did not receive a survey for this protest due to not having a valid email address: "
+		bodyText += "The following people did not receive a survey for this event due to not having a valid email address: "
 		bodyText += strings.Join(attendees, ", ")
 		bodyText += ". "
-		bodyHtml += "<p>The following people did not receive a survey for this protest due to not having a valid email address: <br />"
+		bodyHtml += "<p>The following people did not receive a survey for this event due to not having a valid email address: <br />"
 		bodyHtml += strings.Join(attendees, "<br />")
 		bodyHtml += "</p>"
 	}

--- a/survey_mailer/survey_mailer.go
+++ b/survey_mailer/survey_mailer.go
@@ -1,6 +1,7 @@
 package survey_mailer
 
 import (
+	"errors"
 	"log"
 	"strings"
 	"time"
@@ -11,35 +12,68 @@ import (
 	"github.com/sourcegraph/go-ses"
 )
 
-func sendMissingEmail(eventName string, attendees []string) {
+type SurveyOptions struct {
+	SurveyType     string
+	QueryDate      string
+	QueryEventType string
+	QueryEventName string
+	BodyText       string
+	BodyHtml       string
+	LinkParam      string
+}
+
+func sendMissingEmail(eventName string, attendees []string, sendingErrors []string) {
+	subject := "Missing emails and errors for survey: " + eventName
+	to := config.SurveyMissingEmail
+	bodyText := ""
+	bodyHtml := ""
+
 	if len(attendees) > 0 {
-		to := config.SurveyMissingEmail
-		subject := "Missing emails for survey: " + eventName
-		bodyText := "The following people did not receive a survey for this protest due to not having a valid email address: "
+		bodyText += "The following people did not receive a survey for this protest due to not having a valid email address: "
 		bodyText += strings.Join(attendees, ", ")
-		bodyHtml := bodyText
+		bodyText += ". "
+		bodyHtml += "<p>The following people did not receive a survey for this protest due to not having a valid email address: <br />"
+		bodyHtml += strings.Join(attendees, "<br />")
+		bodyHtml += "</p>"
+	}
+	if len(sendingErrors) > 0 {
+		bodyText += "The following addresses did not receive the email due to sending errors: "
+		bodyText += strings.Join(sendingErrors, ", ")
+		bodyText += ". "
+		bodyHtml += "<p>The following addresses did not receive the email due to sending errors <br />"
+		bodyHtml += strings.Join(sendingErrors, "<br />")
+		bodyHtml += "</p>"
+	}
+
+	if bodyText != "" {
 		sendEmail(to, subject, bodyText, bodyHtml)
+		log.Println("Sending email of missing emails and errors.")
 	}
 }
 
-func sendEmail(to string, subject string, bodyText string, bodyHtml string) {
+func sendEmail(to string, subject string, bodyText string, bodyHtml string) error {
 	from := config.SurveyFromEmail
 	bodyHtml += `<br /><img src="https://adb.dxe.io/static/img/logo1.png" height="46" width="50">`
 	// EnvConfig uses the AWS credentials in the environment
 	// variables $AWS_ACCESS_KEY_ID nd $AWS_SECRET_KEY.
 	_, err := ses.EnvConfig.SendEmailHTML(from, to, subject, bodyText, bodyHtml)
 	if err != nil {
-		log.Printf("Error sending email: %s\n", err)
+		return errors.New(to)
 	}
+	return nil
 }
 
 func bulkSendEmails(event model.Event, subject string, bodyText string, bodyHtml string) {
+	var sendingErrors []string
 	for _, recipient := range event.AttendeeEmails {
 		log.Println("Sending email to:", recipient)
 		// Send email
-		sendEmail(recipient, subject, bodyText, bodyHtml)
+		err := sendEmail(recipient, subject, bodyText, bodyHtml)
+		if err != nil {
+			sendingErrors = append(sendingErrors, err.Error())
+		}
 	}
-	sendMissingEmail(event.EventName, event.AttendeeMissingEmails)
+	sendMissingEmail(event.EventName, event.AttendeeMissingEmails, sendingErrors)
 }
 
 func updateSurveyStatus(db *sqlx.DB, eventId int) {
@@ -53,109 +87,43 @@ func updateSurveyStatus(db *sqlx.DB, eventId int) {
 	}
 }
 
-func surveyMeetup(db *sqlx.DB, queryDate string) {
+func survey(db *sqlx.DB, surveyOptions SurveyOptions) {
+	log.Println("Looking for", surveyOptions.SurveyType, "events on", surveyOptions.QueryDate)
 
-	log.Println("Looking for meetup events on", queryDate)
-
-	// Get today's meetup events that haven't had surveys sent yet
+	// Get events matching query that that haven't had surveys sent yet
 	events, err := model.GetEvents(db, model.GetEventOptions{
-		DateFrom:       queryDate,
-		DateTo:         queryDate,
-		EventType:      "Community",
-		EventNameQuery: "%meetup%",
+		DateFrom:       surveyOptions.QueryDate,
+		DateTo:         surveyOptions.QueryDate,
+		EventType:      surveyOptions.QueryEventType,
+		EventNameQuery: surveyOptions.QueryEventName,
 		SurveySent:     "0",
 	})
 	if err != nil {
-		log.Printf("Failed to get today's meetup events: %v", err)
+		log.Printf("Failed to get events: %v", err)
 		return
 	}
 
 	// Iterate through events
 	for _, event := range events {
-
-		// Set email subject & body
 		subject := "Survey: " + event.EventName
-		eventDateParam := event.EventDate.Format("2006-01-02")
-		bodyText := `Thank you for attending the meetup! Please take this quick survey: https://docs.google.com/forms/d/e/1FAIpQLSfV0smO8sQo1ch-rlX7g9Oz4t_2d3fjGytwrE_yJ8Ez9uLSZQ/viewform?usp=pp_url&entry.1369832182=` + eventDateParam
-		bodyHtml := `<p>Thank you for attending the meetup! Please <a href="https://docs.google.com/forms/d/e/1FAIpQLSfV0smO8sQo1ch-rlX7g9Oz4t_2d3fjGytwrE_yJ8Ez9uLSZQ/viewform?usp=pp_url&entry.1369832182=` + eventDateParam + `">click here</a> to provide feedback which will help us in planning future events.</p>`
+		// set linkParam based on LinkParam option
+		linkParam := ""
+		if surveyOptions.LinkParam == "name" {
+			linkParam = strings.Replace(event.EventName, " ", "+", -1)
+		}
+		if surveyOptions.LinkParam == "date" {
+			linkParam = event.EventDate.Format("2006-01-02")
+		}
+		// build body by replacing LINK_PARAM with the actual link param
+		bodyText := strings.Replace(surveyOptions.BodyText, "LINK_PARAM", linkParam, -1)
+		bodyHtml := strings.Replace(surveyOptions.BodyHtml, "LINK_PARAM", linkParam, -1)
 
-		log.Println("Sending meetup survey for event:", event.EventName)
+		log.Println("Sending", surveyOptions.SurveyType, "survey for event:", event.EventName)
 
 		// send all emails, including "missing" email
 		bulkSendEmails(event, subject, bodyText, bodyHtml)
 
-		// updateSurveyStatus
-		updateSurveyStatus(db, event.ID)
-	}
-}
-
-func surveyChapterMeeting(db *sqlx.DB, queryDate string) {
-
-	log.Println("Looking for chapter meeting events on", queryDate)
-
-	// Get today's chapter meeting events that haven't had surveys sent yet
-	events, err := model.GetEvents(db, model.GetEventOptions{
-		DateFrom:       queryDate,
-		DateTo:         queryDate,
-		EventNameQuery: "%chapter meeting%",
-		SurveySent:     "0",
-	})
-	if err != nil {
-		log.Printf("Failed to get today's chapter meeting events: %v", err)
-		return
-	}
-
-	// Iterate through events
-	for _, event := range events {
-
-		// Set email subject & body
-		subject := "Survey: " + event.EventName
-		eventDateParam := event.EventDate.Format("2006-01-02")
-		bodyText := `Thank you for attending the chapter meeting! Please take this quick survey: https://docs.google.com/forms/d/e/1FAIpQLSfc_mgwH_zYYEQ5MTJwgyvCy5klsY_xrVBXgTDHM8sSxLIJrQ/viewform?usp=pp_url&entry.502269384=` + eventDateParam
-		bodyHtml := `<p>Thank you for attending the chapter meeting! Please <a href="https://docs.google.com/forms/d/e/1FAIpQLSfc_mgwH_zYYEQ5MTJwgyvCy5klsY_xrVBXgTDHM8sSxLIJrQ/viewform?usp=pp_url&entry.502269384=` + eventDateParam + `">click here</a> to take a quick survey.</p>`
-
-		log.Println("Sending chapter meeting survey for event:", event.EventName)
-
-		// send all emails, including "missing" email
-		bulkSendEmails(event, subject, bodyText, bodyHtml)
-
-		// updateSurveyStatus
-		updateSurveyStatus(db, event.ID)
-	}
-}
-
-func surveyProtest(db *sqlx.DB, queryDate string) {
-
-	log.Println("Looking for protest events on", queryDate)
-
-	// Get yesterday's protest events that haven't had surveys sent yet
-	events, err := model.GetEvents(db, model.GetEventOptions{
-		DateFrom:   queryDate,
-		DateTo:     queryDate,
-		EventType:  "%action",
-		SurveySent: "0",
-	})
-
-	if err != nil {
-		log.Printf("Failed to get today's protest events: %v", err)
-		return
-	}
-
-	// Iterate through events
-	for _, event := range events {
-
-		// Set email subject & body
-		subject := "Survey: " + event.EventName
-		eventNameParam := strings.Replace(event.EventName, " ", "+", -1)
-		bodyText := `Thank you for taking part in direct action! Please take this quick survey: https://docs.google.com/forms/d/e/1FAIpQLScfrPtPxmYAroODhBkwUGq753JPykYKNdosg4gUR_SRng8BRQ/viewform?usp=pp_url&entry.466557185=` + eventNameParam + ". If you captured any photos or videos, please upload them here: dxe.io/upload."
-		bodyHtml := `<p>Thank you for taking part in direct action! Please <a href="https://docs.google.com/forms/d/e/1FAIpQLScfrPtPxmYAroODhBkwUGq753JPykYKNdosg4gUR_SRng8BRQ/viewform?usp=pp_url&entry.466557185=` + eventNameParam + `">click here</a> to take a quick survey.</p><p>If you captured any photos or videos, please upload them <a href="http://dxe.io/upload">here</a>.</p>`
-
-		log.Println("Sending protest survey for event:", event.EventName)
-
-		// send all emails, including "missing" email
-		bulkSendEmails(event, subject, bodyText, bodyHtml)
-
-		// updateSurveyStatus
+		// update survey sent status to 1 (true)
 		updateSurveyStatus(db, event.ID)
 	}
 }
@@ -167,29 +135,55 @@ func surveyMailerWrapper(db *sqlx.DB) {
 		}
 	}()
 
-	// Get current hour of day & current day of week
 	now := time.Now()
+	// Calculate current hour of day & current day of week
 	weekday := now.Weekday()
 	hour := now.Hour()
-	// Calculate date of yesterday & today
-	today := now.Format("2006-01-02")
+	// Calculate date of yesterday
 	yesterday := now.AddDate(0, 0, -1).Format("2006-01-02")
 
-	// send protest surveys from previous day daily at 9am
-	if hour == 9 {
-		surveyProtest(db, yesterday)
+	// don't send surveys before 8am or after 5pm since ppl may
+	// be less likely to see the email notification
+	if hour < 8 || hour > 17 {
+		return
 	}
 
-	// send meetup surveys on saturdays at 2pm
-	if weekday == 6 && hour == 14 {
-		surveyMeetup(db, today)
+	// send protest surveys daily
+	survey(db, SurveyOptions{
+		SurveyType:     "protest",
+		QueryDate:      yesterday,
+		QueryEventType: "%Action",
+		QueryEventName: "",
+		BodyText:       `Thank you for taking part in direct action! Please take this quick survey: https://docs.google.com/forms/d/e/1FAIpQLScfrPtPxmYAroODhBkwUGq753JPykYKNdosg4gUR_SRng8BRQ/viewform?usp=pp_url&entry.466557185=LINK_PARAM. If you captured any photos or videos, please upload them here: dxe.io/upload.`,
+		BodyHtml:       `<p>Thank you for taking part in direct action! Please <a href="https://docs.google.com/forms/d/e/1FAIpQLScfrPtPxmYAroODhBkwUGq753JPykYKNdosg4gUR_SRng8BRQ/viewform?usp=pp_url&entry.466557185=LINK_PARAM">click here</a> to take a quick survey.</p><p>If you captured any photos or videos, please upload them <a href="http://dxe.io/upload">here</a>.</p>`,
+		LinkParam:      "name",
+	})
+
+	// only send meetup surveys on sunday
+	if weekday == 0 {
+		survey(db, SurveyOptions{
+			SurveyType:     "meetup",
+			QueryDate:      yesterday,
+			QueryEventType: "Community",
+			QueryEventName: "%Meetup%",
+			BodyText:       `Thank you for attending the meetup! Please take this quick survey: https://docs.google.com/forms/d/e/1FAIpQLSfV0smO8sQo1ch-rlX7g9Oz4t_2d3fjGytwrE_yJ8Ez9uLSZQ/viewform?usp=pp_url&entry.1369832182=LINK_PARAM`,
+			BodyHtml:       `<p>Thank you for attending the meetup! Please <a href="https://docs.google.com/forms/d/e/1FAIpQLSfV0smO8sQo1ch-rlX7g9Oz4t_2d3fjGytwrE_yJ8Ez9uLSZQ/viewform?usp=pp_url&entry.1369832182=LINK_PARAM">click here</a> to provide feedback which will help us in planning future events.</p>`,
+			LinkParam:      "date",
+		})
 	}
 
-	// send chapter mtg surveys on sun at 4pm
-	if weekday == 0 && hour == 16 {
-		surveyChapterMeeting(db, today)
+	// only send chapter mtg surveys on monday
+	if weekday == 1 {
+		survey(db, SurveyOptions{
+			SurveyType:     "chapter meeting",
+			QueryDate:      yesterday,
+			QueryEventType: "",
+			QueryEventName: "%Chapter Meeting%",
+			BodyText:       `Thank you for attending the chapter meeting! Please take this quick survey: https://docs.google.com/forms/d/e/1FAIpQLSfc_mgwH_zYYEQ5MTJwgyvCy5klsY_xrVBXgTDHM8sSxLIJrQ/viewform?usp=pp_url&entry.502269384=LINK_PARAM`,
+			BodyHtml:       `<p>Thank you for attending the chapter meeting! Please <a href="https://docs.google.com/forms/d/e/1FAIpQLSfc_mgwH_zYYEQ5MTJwgyvCy5klsY_xrVBXgTDHM8sSxLIJrQ/viewform?usp=pp_url&entry.502269384=LINK_PARAM">click here</a> to take a quick survey.</p>`,
+			LinkParam:      "date",
+		})
 	}
-
 }
 
 // Sends surveys based on event attendance every 60 minutes.

--- a/survey_mailer/survey_mailer.go
+++ b/survey_mailer/survey_mailer.go
@@ -1,0 +1,204 @@
+package survey_mailer
+
+import (
+	"log"
+	"strings"
+	"time"
+
+	"github.com/dxe/adb/config"
+	"github.com/dxe/adb/model"
+	"github.com/jmoiron/sqlx"
+	"github.com/sourcegraph/go-ses"
+)
+
+func sendMissingEmail(eventName string, attendees []string) {
+	if len(attendees) > 0 {
+		to := config.SurveyMissingEmail
+		subject := "Missing emails for survey: " + eventName
+		bodyText := "The following people did not receive a survey for this protest due to not having a valid email address: "
+		bodyText += strings.Join(attendees, ", ")
+		bodyHtml := bodyText
+		sendEmail(to, subject, bodyText, bodyHtml)
+	}
+}
+
+func sendEmail(to string, subject string, bodyText string, bodyHtml string) {
+	from := config.SurveyFromEmail
+	bodyHtml += `<br /><img src="https://adb.dxe.io/static/img/logo1.png" height="46" width="50">`
+	// EnvConfig uses the AWS credentials in the environment
+	// variables $AWS_ACCESS_KEY_ID nd $AWS_SECRET_KEY.
+	_, err := ses.EnvConfig.SendEmailHTML(from, to, subject, bodyText, bodyHtml)
+	if err != nil {
+		log.Printf("Error sending email: %s\n", err)
+	}
+}
+
+func bulkSendEmails(event model.Event, subject string, bodyText string, bodyHtml string) {
+	for _, recipient := range event.AttendeeEmails {
+		log.Println("Sending email to:", recipient)
+		// Send email
+		sendEmail(recipient, subject, bodyText, bodyHtml)
+	}
+	sendMissingEmail(event.EventName, event.AttendeeMissingEmails)
+}
+
+func updateSurveyStatus(db *sqlx.DB, eventId int) {
+	// Update "survey_sent" to true (1)
+	_, err := model.UpdateEventSurveyStatus(db, model.Event{
+		ID:         eventId,
+		SurveySent: 1,
+	})
+	if err != nil {
+		log.Println("ERROR:", err)
+	}
+}
+
+func surveyMeetup(db *sqlx.DB, queryDate string) {
+
+	log.Println("Looking for meetup events on", queryDate)
+
+	// Get today's meetup events that haven't had surveys sent yet
+	events, err := model.GetEvents(db, model.GetEventOptions{
+		DateFrom:       queryDate,
+		DateTo:         queryDate,
+		EventType:      "Community",
+		EventNameQuery: "%meetup%",
+		SurveySent:     "0",
+	})
+	if err != nil {
+		log.Printf("Failed to get today's meetup events: %v", err)
+		return
+	}
+
+	// Iterate through events
+	for _, event := range events {
+
+		// Set email subject & body
+		subject := "Survey: " + event.EventName
+		eventDateParam := event.EventDate.Format("2006-01-02")
+		bodyText := `Thank you for attending the meetup! Please take this quick survey: https://docs.google.com/forms/d/e/1FAIpQLSfV0smO8sQo1ch-rlX7g9Oz4t_2d3fjGytwrE_yJ8Ez9uLSZQ/viewform?usp=pp_url&entry.1369832182=` + eventDateParam
+		bodyHtml := `<p>Thank you for attending the meetup! Please <a href="https://docs.google.com/forms/d/e/1FAIpQLSfV0smO8sQo1ch-rlX7g9Oz4t_2d3fjGytwrE_yJ8Ez9uLSZQ/viewform?usp=pp_url&entry.1369832182=` + eventDateParam + `">click here</a> to provide feedback which will help us in planning future events.</p>`
+
+		log.Println("Sending meetup survey for event:", event.EventName)
+
+		// send all emails, including "missing" email
+		bulkSendEmails(event, subject, bodyText, bodyHtml)
+
+		// updateSurveyStatus
+		updateSurveyStatus(db, event.ID)
+	}
+}
+
+func surveyChapterMeeting(db *sqlx.DB, queryDate string) {
+
+	log.Println("Looking for chapter meeting events on", queryDate)
+
+	// Get today's chapter meeting events that haven't had surveys sent yet
+	events, err := model.GetEvents(db, model.GetEventOptions{
+		DateFrom:       queryDate,
+		DateTo:         queryDate,
+		EventNameQuery: "%chapter meeting%",
+		SurveySent:     "0",
+	})
+	if err != nil {
+		log.Printf("Failed to get today's chapter meeting events: %v", err)
+		return
+	}
+
+	// Iterate through events
+	for _, event := range events {
+
+		// Set email subject & body
+		subject := "Survey: " + event.EventName
+		eventDateParam := event.EventDate.Format("2006-01-02")
+		bodyText := `Thank you for attending the chapter meeting! Please take this quick survey: https://docs.google.com/forms/d/e/1FAIpQLSfc_mgwH_zYYEQ5MTJwgyvCy5klsY_xrVBXgTDHM8sSxLIJrQ/viewform?usp=pp_url&entry.502269384=` + eventDateParam
+		bodyHtml := `<p>Thank you for attending the chapter meeting! Please <a href="https://docs.google.com/forms/d/e/1FAIpQLSfc_mgwH_zYYEQ5MTJwgyvCy5klsY_xrVBXgTDHM8sSxLIJrQ/viewform?usp=pp_url&entry.502269384=` + eventDateParam + `">click here</a> to take a quick survey.</p>`
+
+		log.Println("Sending chapter meeting survey for event:", event.EventName)
+
+		// send all emails, including "missing" email
+		bulkSendEmails(event, subject, bodyText, bodyHtml)
+
+		// updateSurveyStatus
+		updateSurveyStatus(db, event.ID)
+	}
+}
+
+func surveyProtest(db *sqlx.DB, queryDate string) {
+
+	log.Println("Looking for protest events on", queryDate)
+
+	// Get yesterday's protest events that haven't had surveys sent yet
+	events, err := model.GetEvents(db, model.GetEventOptions{
+		DateFrom:   queryDate,
+		DateTo:     queryDate,
+		EventType:  "%action",
+		SurveySent: "0",
+	})
+
+	if err != nil {
+		log.Printf("Failed to get today's protest events: %v", err)
+		return
+	}
+
+	// Iterate through events
+	for _, event := range events {
+
+		// Set email subject & body
+		subject := "Survey: " + event.EventName
+		eventNameParam := strings.Replace(event.EventName, " ", "+", -1)
+		bodyText := `Thank you for taking part in direct action! Please take this quick survey: https://docs.google.com/forms/d/e/1FAIpQLScfrPtPxmYAroODhBkwUGq753JPykYKNdosg4gUR_SRng8BRQ/viewform?usp=pp_url&entry.466557185=` + eventNameParam + ". If you captured any photos or videos, please upload them here: dxe.io/upload."
+		bodyHtml := `<p>Thank you for taking part in direct action! Please <a href="https://docs.google.com/forms/d/e/1FAIpQLScfrPtPxmYAroODhBkwUGq753JPykYKNdosg4gUR_SRng8BRQ/viewform?usp=pp_url&entry.466557185=` + eventNameParam + `">click here</a> to take a quick survey.</p><p>If you captured any photos or videos, please upload them <a href="http://dxe.io/upload">here</a>.</p>`
+
+		log.Println("Sending protest survey for event:", event.EventName)
+
+		// send all emails, including "missing" email
+		bulkSendEmails(event, subject, bodyText, bodyHtml)
+
+		// updateSurveyStatus
+		updateSurveyStatus(db, event.ID)
+	}
+}
+
+func surveyMailerWrapper(db *sqlx.DB) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Println("Recovered from panic in survey mailer", r)
+		}
+	}()
+
+	// Get current hour of day & current day of week
+	weekday := time.Now().Weekday()
+	hour := time.Now().Hour()
+	// Calculate date of yesterday & today
+	today := time.Now().Format("2006-01-02")
+	yesterday := time.Now().AddDate(0, 0, -1).Format("2006-01-02")
+
+	// send protest surveys from previous day daily at 9am
+	if hour == 9 {
+		surveyProtest(db, yesterday)
+	}
+
+	// send meetup surveys on saturdays at 2pm
+	if weekday == 6 && hour == 14 {
+		surveyMeetup(db, today)
+	}
+
+	// send chapter mtg surveys on sun at 4pm
+	if weekday == 0 && hour == 16 {
+		surveyChapterMeeting(db, today)
+	}
+
+}
+
+// Sends surveys based on event attendance every 60 minutes.
+// Should be run in a goroutine.
+func StartSurveyMailer(db *sqlx.DB) {
+	for {
+		log.Println("Starting survey mailer")
+		surveyMailerWrapper(db)
+		log.Println("Finished survey mailer")
+		// TODO(jake): change this to 60 min before deploying
+		time.Sleep(60 * time.Minute)
+	}
+}

--- a/survey_mailer/survey_mailer.go
+++ b/survey_mailer/survey_mailer.go
@@ -1,11 +1,11 @@
 package survey_mailer
 
 import (
+	"fmt"
+	"html"
 	"log"
 	"strings"
 	"time"
-	"html"
-	"fmt"
 
 	"github.com/dxe/adb/config"
 	"github.com/dxe/adb/model"
@@ -69,7 +69,7 @@ func bulkSendEmails(event model.Event, subject string, bodyText string, bodyHtml
 	var sendingErrors []string
 	for i, recipient := range event.Attendees {
 		receipientEmail := event.AttendeeEmails[i]
-		if (receipientEmail == "") {
+		if receipientEmail == "" {
 			missingEmails = append(missingEmails, recipient)
 			continue
 		}

--- a/survey_mailer/survey_mailer.go
+++ b/survey_mailer/survey_mailer.go
@@ -56,7 +56,7 @@ func sendEmail(to string, subject string, bodyText string, bodyHtml string) erro
 	from := config.SurveyFromEmail
 	bodyHtml += `<br /><img src="https://adb.dxe.io/static/img/logo1.png" height="46" width="50">`
 	// EnvConfig uses the AWS credentials in the environment
-	// variables $AWS_ACCESS_KEY_ID nd $AWS_SECRET_KEY.
+	// variables $AWS_ACCESS_KEY_ID and $AWS_SECRET_KEY.
 	_, err := ses.EnvConfig.SendEmailHTML(from, to, subject, bodyText, bodyHtml)
 	if err != nil {
 		return err

--- a/survey_mailer/survey_mailer.go
+++ b/survey_mailer/survey_mailer.go
@@ -198,7 +198,6 @@ func StartSurveyMailer(db *sqlx.DB) {
 		log.Println("Starting survey mailer")
 		surveyMailerWrapper(db)
 		log.Println("Finished survey mailer")
-		// TODO(jake): change this to 60 min before deploying
 		time.Sleep(60 * time.Minute)
 	}
 }

--- a/survey_mailer/survey_mailer.go
+++ b/survey_mailer/survey_mailer.go
@@ -168,11 +168,12 @@ func surveyMailerWrapper(db *sqlx.DB) {
 	}()
 
 	// Get current hour of day & current day of week
-	weekday := time.Now().Weekday()
-	hour := time.Now().Hour()
+	now := time.Now()
+	weekday := now.Weekday()
+	hour := now.Hour()
 	// Calculate date of yesterday & today
-	today := time.Now().Format("2006-01-02")
-	yesterday := time.Now().AddDate(0, 0, -1).Format("2006-01-02")
+	today := now.Format("2006-01-02")
+	yesterday := now.AddDate(0, 0, -1).Format("2006-01-02")
 
 	// send protest surveys from previous day daily at 9am
 	if hour == 9 {


### PR DESCRIPTION
Currently, we have mysql scripts that run on a regular basis to export event attendance data to csv files. These csv files are publicly accessible and imported into Google Sheets. From there, there are multiple Google Apps Scripts that run to send survey emails via Gmail.

This pull request will add all of the survey-sending functionality directly into the ADB.

Here are the steps I will follow when merging this:
- Disable current GAS scripts on various spreadsheets: meetup, chapter mtg, protest.
- Add survey_sent col to prod events database (and set to 1 for previous day's events to prevent sending duplicates).
- Add new environment variables to docker instance (see readme).
- Remove surveys.sql from mysql-files and delete the csv files from www.
