### PR TITLE
remove unused model options

### DIFF
--- a/main.go
+++ b/main.go
@@ -1002,7 +1002,7 @@ func (c MainController) WorkingGroupSaveHandler(w http.ResponseWriter, r *http.R
 }
 
 func (c MainController) WorkingGroupListHandler(w http.ResponseWriter, r *http.Request) {
-	wgs, err := model.GetWorkingGroupsJSON(c.db, model.WorkingGroupQueryOptions{})
+	wgs, err := model.GetWorkingGroupsJSON(c.db)
 	if err != nil {
 		sendErrorMessage(w, err)
 		return
@@ -1067,7 +1067,7 @@ func (c MainController) CircleGroupSaveHandler(w http.ResponseWriter, r *http.Re
 }
 
 func (c MainController) CircleGroupListHandler(w http.ResponseWriter, r *http.Request) {
-	cirs, err := model.GetCircleGroupsJSON(c.db, model.CircleGroupQueryOptions{})
+	cirs, err := model.GetCircleGroupsJSON(c.db)
 	if err != nil {
 		sendErrorMessage(w, err)
 		return
@@ -1132,7 +1132,7 @@ func (c MainController) ActivistListBasicHandler(w http.ResponseWriter, r *http.
 }
 
 func (c MainController) UserListHandler(w http.ResponseWriter, r *http.Request) {
-	users, err := model.GetUsersJSON(c.db, model.GetUserOptions{})
+	users, err := model.GetUsersJSON(c.db)
 
 	if err != nil {
 		sendErrorMessage(w, err)

--- a/model/adb_auth.go
+++ b/model/adb_auth.go
@@ -49,11 +49,7 @@ type UserJSON struct {
 }
 
 type GetUserOptions struct {
-	ID       int
-	Email    string
-	Name     string
-	Admin    bool
-	Disabled bool
+	ID int
 }
 
 type GetUsersRolesOptions struct {
@@ -128,12 +124,8 @@ FROM adb_users
 	return *adbUser, nil
 }
 
-func GetUsersJSON(db *sqlx.DB, options GetUserOptions) ([]UserJSON, error) {
-	if options.ID != 0 {
-		return nil, errors.New("GetUsersJSON: Cannot include ID in options")
-	}
-
-	return getUsersJSON(db, options)
+func GetUsersJSON(db *sqlx.DB) ([]UserJSON, error) {
+	return getUsersJSON(db, GetUserOptions{})
 }
 
 func getUsersJSON(db *sqlx.DB, options GetUserOptions) ([]UserJSON, error) {

--- a/model/working_groups_test.go
+++ b/model/working_groups_test.go
@@ -105,11 +105,7 @@ func TestCreateWorkingGroup_insertAndFetchWorkingGroupWithMembersByNameAndID(t *
 	require.NoError(t, err)
 	workingGroup.ID = id
 
-	fetchedGroup, err := GetWorkingGroup(db, WorkingGroupQueryOptions{GroupName: "The Citadel"})
-	require.NoError(t, err)
-	validateReturnedWorkingGroup(t, workingGroup, fetchedGroup)
-
-	fetchedGroup2, err := GetWorkingGroup(db, WorkingGroupQueryOptions{GroupName: "The Citadel", GroupID: id})
+	fetchedGroup2, err := GetWorkingGroup(db, WorkingGroupQueryOptions{GroupID: id})
 	require.NoError(t, err)
 	validateReturnedWorkingGroup(t, workingGroup, fetchedGroup2)
 }


### PR DESCRIPTION
The GetFoosJSON functions don't need to take Options parameters, since
they're not actually allowed to set any options anyway. Also,
eliminate the unused options (e.g., the "Name" field for circles and
working groups) and unimplemented options (e.g., most of the "User"
fields).

Low hanging fruit in trying to simplify the DB model to make better
sense of it.