### PR TITLE
[WIP] Add CSRF protection to admin endpoints

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -20,8 +20,8 @@ var (
 	Route1 = mustGetenv("ROUTE_1", "/route1", true)
 	Route2 = mustGetenv("ROUTE_2", "/route2", true)
 
-	CookieSecret = mustGetenv("COOKIE_SECRET", "some-fake-secret")
-	CsrfAuthKey  = mustGetenv("CSRF_AUTH_KEY", "")
+	CookieSecret = mustGetenv("COOKIE_SECRET", "some-fake-secret", true)
+	CsrfAuthKey  = mustGetenv("CSRF_AUTH_KEY", "", true)
 
 	// Path to Google API oauth client_secrets.json file, with
 	// access to the following scope:

--- a/config/config.go
+++ b/config/config.go
@@ -20,7 +20,8 @@ var (
 	Route1 = mustGetenv("ROUTE_1", "/route1", true)
 	Route2 = mustGetenv("ROUTE_2", "/route2", true)
 
-	CookieSecret = mustGetenv("COOKIE_SECRET", "some-fake-secret", true)
+	CookieSecret = mustGetenv("COOKIE_SECRET", "some-fake-secret")
+	CsrfAuthKey = mustGetenv("CSRF_AUTH_KEY", "")
 
 	// Path to Google API oauth client_secrets.json file, with
 	// access to the following scope:

--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,7 @@ var (
 	Route2 = mustGetenv("ROUTE_2", "/route2", true)
 
 	CookieSecret = mustGetenv("COOKIE_SECRET", "some-fake-secret")
-	CsrfAuthKey = mustGetenv("CSRF_AUTH_KEY", "")
+	CsrfAuthKey  = mustGetenv("CSRF_AUTH_KEY", "")
 
 	// Path to Google API oauth client_secrets.json file, with
 	// access to the following scope:

--- a/frontend/UserList.vue
+++ b/frontend/UserList.vue
@@ -316,10 +316,12 @@ export default Vue.extend({
       // If the specified Role already exists in the Current User's role list,
       // then we assume the role should be removed.
       const existingRole = this.currentUser.roles.indexOf(role) >= 0;
+      const csrfToken = $('meta[name="csrf-token"]').attr("content")
 
       $.ajax({
         url: existingRole ? '/users-roles/remove' : '/users-roles/add',
         method: 'POST',
+        headers: { "X-CSRF-Token": csrfToken },
         contentType: 'application/json',
         data: JSON.stringify({
           user_id: this.currentUser.id,

--- a/frontend/UserList.vue
+++ b/frontend/UserList.vue
@@ -198,10 +198,12 @@ export default Vue.extend({
       // try to save twice. Re-enable it when we get any response back
       // from the server (even an error).
       this.disableConfirmButton = true;
+      const csrfToken = $('meta[name="csrf-token"]').attr("content")
 
       $.ajax({
         url: '/user/save',
         method: 'POST',
+        headers: { "X-CSRF-Token": csrfToken },
         contentType: 'application/json',
         data: JSON.stringify(this.currentUser),
         success: (data) => {

--- a/frontend/UserList.vue
+++ b/frontend/UserList.vue
@@ -198,12 +198,12 @@ export default Vue.extend({
       // try to save twice. Re-enable it when we get any response back
       // from the server (even an error).
       this.disableConfirmButton = true;
-      const csrfToken = $('meta[name="csrf-token"]').attr("content")
+      const csrfToken = $('meta[name="csrf-token"]').attr('content');
 
       $.ajax({
         url: '/user/save',
         method: 'POST',
-        headers: { "X-CSRF-Token": csrfToken },
+        headers: { 'X-CSRF-Token': csrfToken },
         contentType: 'application/json',
         data: JSON.stringify(this.currentUser),
         success: (data) => {
@@ -318,12 +318,12 @@ export default Vue.extend({
       // If the specified Role already exists in the Current User's role list,
       // then we assume the role should be removed.
       const existingRole = this.currentUser.roles.indexOf(role) >= 0;
-      const csrfToken = $('meta[name="csrf-token"]').attr("content")
+      const csrfToken = $('meta[name="csrf-token"]').attr('content');
 
       $.ajax({
         url: existingRole ? '/users-roles/remove' : '/users-roles/add',
         method: 'POST',
-        headers: { "X-CSRF-Token": csrfToken },
+        headers: { 'X-CSRF-Token': csrfToken },
         contentType: 'application/json',
         data: JSON.stringify({
           user_id: this.currentUser.id,

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/getsentry/sentry-go v0.3.1
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect
+	github.com/gorilla/csrf v1.6.2
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/sessions v1.2.0
 	github.com/jmoiron/sqlx v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gorilla/csrf v1.6.2 h1:QqQ/OWwuFp4jMKgBFAzJVW3FMULdyUW7JoM4pEWuqKg=
+github.com/gorilla/csrf v1.6.2/go.mod h1:7tSf8kmjNYr7IWDCYhd3U8Ck34iQ/Yw5CJu7bAkHEGI=
 github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
@@ -167,6 +169,7 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
+github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dxe/adb/model"
 	"github.com/dxe/adb/survey_mailer"
 	"github.com/getsentry/sentry-go"
+	"github.com/gorilla/csrf"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 	"github.com/jmoiron/sqlx"
@@ -116,9 +117,13 @@ func noCacheHandler(h http.Handler) http.Handler {
 func router() (*mux.Router, *sqlx.DB) {
 	db := model.NewDB(config.DBDataSource())
 	main := MainController{db: db}
+	csrfMiddleware := csrf.Protect([]byte("1FnjxBuVHvLvvIN6mpjabBR0O3eJvKxu"))
 
 	router := mux.NewRouter()
 	members.Route(router.PathPrefix("/members").Subrouter(), db)
+
+	admin := router.PathPrefix("").Subrouter()
+	admin.Use(csrfMiddleware)
 
 	// Unauthed pages
 	router.HandleFunc("/login", main.LoginHandler)
@@ -153,7 +158,7 @@ func router() (*mux.Router, *sqlx.DB) {
 	router.Handle("/list_circles", alice.New(main.authOrganizerMiddleware).ThenFunc(main.ListCirclesHandler))
 
 	// Authed Admin pages
-	router.Handle("/admin/users", alice.New(main.authAdminMiddleware).ThenFunc(main.ListUsersHandler))
+	admin.Handle("/admin/users", alice.New(main.authAdminMiddleware).ThenFunc(main.ListUsersHandler))
 
 	// Unauthed API
 	router.HandleFunc("/tokensignin", main.TokenSignInHandler)
@@ -184,12 +189,12 @@ func router() (*mux.Router, *sqlx.DB) {
 	router.Handle("/circle/delete", alice.New(main.apiOrganizerAuthMiddleware).ThenFunc(main.CircleGroupDeleteHandler))
 
 	// Authed Admin API
-	router.Handle("/user/list", alice.New(main.apiAdminAuthMiddleware).ThenFunc(main.UserListHandler))
-	router.Handle("/user/save", alice.New(main.apiAdminAuthMiddleware).ThenFunc(main.UserSaveHandler))
-	router.Handle("/user/delete", alice.New(main.apiAdminAuthMiddleware).ThenFunc(main.UserDeleteHandler))
+	admin.Handle("/user/list", alice.New(main.apiAdminAuthMiddleware).ThenFunc(main.UserListHandler))
+	admin.Handle("/user/save", alice.New(main.apiAdminAuthMiddleware).ThenFunc(main.UserSaveHandler))
+	admin.Handle("/user/delete", alice.New(main.apiAdminAuthMiddleware).ThenFunc(main.UserDeleteHandler))
 	// Authed Admin API for managing Users Roles
-	router.Handle("/users-roles/add", alice.New(main.apiAdminAuthMiddleware).ThenFunc(main.UsersRolesAddHandler))
-	router.Handle("/users-roles/remove", alice.New(main.apiAdminAuthMiddleware).ThenFunc(main.UsersRolesRemoveHandler))
+	admin.Handle("/users-roles/add", alice.New(main.apiAdminAuthMiddleware).ThenFunc(main.UsersRolesAddHandler))
+	admin.Handle("/users-roles/remove", alice.New(main.apiAdminAuthMiddleware).ThenFunc(main.UsersRolesRemoveHandler))
 
 	// Pprof debug routes
 	router.HandleFunc("/debug/pprof/", pprof.Index)
@@ -608,6 +613,7 @@ var templates = template.Must(template.New("").Funcs(
 type PageData struct {
 	PageName  string
 	Data      interface{}
+	CsrfField string
 	MainRole  string
 	UserName  string
 	UserEmail string
@@ -618,6 +624,7 @@ type PageData struct {
 // Render a page. All templates that load a header expect a PageData
 // object.
 func renderPage(w io.Writer, r *http.Request, name string, pageData PageData) {
+	pageData.CsrfField = csrf.Token(r)
 	pageData.StaticResourcesHash = config.StaticResourcesHash()
 	pageData.MainRole = getUserMainRole(getUserFromContext(r.Context()))
 	pageData.UserName = getUserName(getUserFromContext(r.Context()))
@@ -848,7 +855,7 @@ func (c MainController) EventGetHandler(w http.ResponseWriter, r *http.Request) 
 func (c MainController) EventSaveHandler(w http.ResponseWriter, r *http.Request) {
 	event, err := model.CleanEventData(c.db, r.Body)
 	if err != nil {
-		sendErrorMessage(w, err)
+		sendErrorMessage(w, err) // TODO: don't send error message to user
 		return
 	}
 
@@ -1305,5 +1312,6 @@ func main() {
 
 	fmt.Println("IsProd =", config.IsProd)
 	fmt.Println("Listening on localhost:" + config.Port)
+	// CSRF := csrf.Protect([]byte("1FnjxBuVHvLvvIN6mpjabBR0O3eJvKxu"))
 	log.Fatal(http.ListenAndServe(":"+config.Port, n))
 }

--- a/templates/header.html
+++ b/templates/header.html
@@ -6,6 +6,7 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+    <meta name="csrf-token" content="{{ .CsrfField }}">
     <title>Activist Database</title>
     <link rel="icon" type="image/png"
      href="/static/img/favicon.png" />


### PR DESCRIPTION
The CSRF tokens that are generated can be reused for subsequent requests.

@mdempsky It would be useful to verify that these tokens can't be used across user accounts -- does that need to be tested in prod? E.g., I shouldn't be able to log in as myself, collect the CSRF base token and a request token, and then trick a user into submitting these values and have the server accept the request.

To generate the 32-byte random key for CSRF authentication, you can use `LC_ALL=C tr -dc '[:alnum:]' < /dev/urandom | head -c20`.