### PR TITLE
added new API endpoints for discord bot

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -14,7 +14,8 @@ var (
 	DBName     = mustGetenv("DB_NAME", "adb_db", true)
 	DBProtocol = mustGetenv("DB_PROTOCOL", "", true)
 
-	Port = mustGetenv("PORT", "8080", true)
+	Port    = mustGetenv("PORT", "8080", true)
+	UrlPath = mustGetenv("ADB_URL_PATH", "http://localhost:"+Port, true)
 
 	Route0 = mustGetenv("ROUTE_0", "/route0", true)
 	Route1 = mustGetenv("ROUTE_1", "/route1", true)
@@ -47,6 +48,10 @@ var (
 	// For members.dxesf.org
 	MembersClientID     = mustGetenv("MEMBERS_CLIENT_ID", "", false)
 	MembersClientSecret = mustGetenv("MEMBERS_CLIENT_SECRET", "", false)
+
+	// For Discord bot
+	DiscordSecret    = mustGetenv("DISCORD_SECRET", "some-fake-secret", false)
+	DiscordFromEmail = mustGetenv("DISCORD_FROM_EMAIL", "", false)
 )
 
 func mustGetenv(key, fallback string, mandatory bool) string {

--- a/config/config.go
+++ b/config/config.go
@@ -52,6 +52,7 @@ var (
 	// For Discord bot
 	DiscordSecret    = mustGetenv("DISCORD_SECRET", "some-fake-secret", false)
 	DiscordFromEmail = mustGetenv("DISCORD_FROM_EMAIL", "", false)
+	SupportEmail     = mustGetenv("SUPPORT_EMAIL", "tech@dxe.io", false)
 )
 
 func mustGetenv(key, fallback string, mandatory bool) string {

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
@@ -30,6 +31,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/justinas/alice"
 	"github.com/pkg/errors"
+	"github.com/sourcegraph/go-ses"
 	"github.com/urfave/negroni"
 )
 
@@ -73,6 +75,12 @@ func stripPort(ip string) string {
 		return strings.Split(ip, ":")[0]
 	}
 	return ip
+}
+
+func generateToken() string {
+	b := make([]byte, 32)
+	rand.Read(b)
+	return fmt.Sprintf("%x", b)
 }
 
 var sessionStore = sessions.NewCookieStore([]byte(config.CookieSecret))
@@ -238,6 +246,11 @@ func router() (*mux.Router, *sqlx.DB) {
 	// Authed Admin API for managing Users Roles
 	admin.Handle("/users-roles/add", alice.New(main.apiAdminAuthMiddleware).ThenFunc(main.UsersRolesAddHandler))
 	admin.Handle("/users-roles/remove", alice.New(main.apiAdminAuthMiddleware).ThenFunc(main.UsersRolesRemoveHandler))
+
+	// Discord API
+	router.Handle("/discord/status", alice.New(main.discordBotAuthMiddleware).ThenFunc(main.DiscordStatusHandler))
+	router.Handle("/discord/generate", alice.New(main.discordBotAuthMiddleware).ThenFunc(main.DiscordGenerateHandler))
+	router.HandleFunc("/discord/confirm/{id:[0-9]+}/{token:[a-zA-Z0-9]+}", main.DiscordConfirmHandler)
 
 	// Pprof debug routes
 	router.HandleFunc("/debug/pprof/", pprof.Index)
@@ -1545,6 +1558,159 @@ func (c MainController) ListAllChapters(w http.ResponseWriter, r *http.Request) 
 
 	// return json
 	writeJSON(w, chapters)
+}
+
+// testing this
+func (c MainController) discordBotAuthMiddleware(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		err := r.ParseForm()
+		if err != nil {
+			http.Error(w, http.StatusText(400), 400)
+			return
+		}
+
+		// check that discord auth matches (shared secret w/ discord bot)
+		discordAuth := r.PostFormValue("auth")
+		if discordAuth != config.DiscordSecret {
+			http.Error(w, http.StatusText(401), 401)
+			return
+		}
+
+		h.ServeHTTP(w, r)
+	})
+}
+
+func (c MainController) DiscordStatusHandler(w http.ResponseWriter, r *http.Request) {
+	err := r.ParseForm()
+	if err != nil {
+		writeJSON(w, map[string]interface{}{
+			"status": "error parsing form",
+		})
+		return
+	}
+
+	discordUserID, err := strconv.Atoi(r.PostFormValue("id"))
+
+	// see if a record exists for this user id in the discord_users table (pending, confirmed, or not found)
+	status, err := model.GetDiscordUserStatus(c.db, discordUserID)
+	if err != nil {
+		panic(err.Error())
+	}
+	log.Println("Discord user status:", status)
+
+	// return the status found from database
+	writeJSON(w, map[string]interface{}{
+		"status": status,
+	})
+}
+
+func (c MainController) DiscordGenerateHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(w, http.StatusText(400), 400)
+		return
+	}
+
+	var user model.DiscordUser
+	userID, err := strconv.Atoi(r.PostFormValue("id"))
+	if err != nil {
+		http.Error(w, http.StatusText(400), 400)
+		return
+	}
+	user.ID = userID
+	user.Email = r.PostFormValue("email")
+	user.Token = generateToken()
+
+	// confirm that this email exists in ADB. if not, return error.
+	activists, err := model.GetActivistsByEmail(c.db, user.Email)
+	if len(activists) < 1 {
+		writeJSON(w, map[string]interface{}{
+			"status": "invalid email",
+		})
+		return
+	}
+
+	// check that user isn't already confirmed
+	status, err := model.GetDiscordUserStatus(c.db, user.ID)
+	if err != nil {
+		panic(err.Error())
+	}
+	if status == model.Confirmed {
+		writeJSON(w, map[string]interface{}{
+			"status": "already confirmed",
+		})
+		return
+	}
+
+	// INSERT/REPLACE into database (only allows one record per discord ID)
+	err = model.InsertOrUpdateDiscordUser(c.db, user)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	// trigger email to be sent w/ verification link
+	if config.DiscordFromEmail != "" && config.AWSAccessKey != "" && config.AWSSecretKey != "" && config.AWSSESEndpoint != "" {
+		subjectText := "Please verify your email"
+		// TODO: make nicer looking email
+		confirmLink := config.UrlPath + "/discord/confirm/" + strconv.Itoa(user.ID) + "/" + user.Token
+		bodyText := "Hello, Please click this link to verify your email address: " + confirmLink + " Cheers, The DxE Discord Bot"
+		bodyHtml := `<p>Hello,</p><p>Please click the link below to verify your email address.</p><p><a href="` + confirmLink + `">CONFIRM</a></p><p>Cheers,<br />The DxE Discord Bot</p><br /><br /><br /><p><em>This email was sent to you by DxE to verify your email address for Discord. If you did not request this verification, please do not click the above link.</em></p>`
+		_, err = ses.EnvConfig.SendEmailHTML(config.DiscordFromEmail, user.Email, subjectText, bodyText, bodyHtml)
+		if err != nil {
+			panic(err.Error())
+		}
+	} else {
+		log.Printf("WARNING: Discord confirmation email could not be sent to %v due to missing SES configuration.\n", user.Email)
+	}
+
+	writeJSON(w, map[string]interface{}{
+		"status": "success",
+	})
+}
+
+func (c MainController) DiscordConfirmHandler(w http.ResponseWriter, r *http.Request) {
+
+	var user model.DiscordUser
+
+	vars := mux.Vars(r)
+	id, err := strconv.Atoi(vars["id"])
+	if err != nil {
+		panic(err)
+	}
+	user.ID = id
+	user.Token = vars["token"]
+
+	// try to confirm user
+	_, err = model.ConfirmDiscordUser(c.db, user)
+
+	// get user status
+	status, err := model.GetDiscordUserStatus(c.db, user.ID)
+	if err != nil {
+		panic(err.Error())
+	}
+	log.Println("Discord user confirmation status:", status)
+
+	// if status = confirmed, we are good
+	if status == model.Confirmed {
+		// render page saying confirmation successful (or not) & link back to discord
+		renderPage(w, r, "discord", PageData{
+			PageName: "Success",
+			Data: map[string]interface{}{
+				"message": "Your email has been confirmed.",
+			},
+		})
+		// TODO: assign roles in discord immediately once bot is ready to take requests
+		return
+	}
+
+	// render error page
+	renderPage(w, r, "discord", PageData{
+		PageName: "Error",
+		Data: map[string]interface{}{
+			"message": "There was a problem verifying your email. Please try again or contact " + template.HTML(`<a href="mailto:tech@dxe.io">tech@dxe.io</a>`) + ".",
+		},
+	})
+	return
 }
 
 func main() {

--- a/model/activist.go
+++ b/model/activist.go
@@ -620,6 +620,23 @@ func getActivists(db *sqlx.DB, name string) ([]Activist, error) {
 	return activists, nil
 }
 
+func GetActivistsByEmail(db *sqlx.DB, email string) ([]Activist, error) {
+	var queryArgs []interface{}
+	query := selectActivistBaseQuery
+
+	if email != "" {
+		query += " WHERE email = ? AND hidden = 0"
+		queryArgs = append(queryArgs, email)
+	}
+
+	var activists []Activist
+	if err := db.Select(&activists, query, queryArgs...); err != nil {
+		return nil, errors.Wrapf(err, "failed to get activists for %s", email)
+	}
+
+	return activists, nil
+}
+
 func GetChapterMembers(db *sqlx.DB) ([]Activist, error) {
 	query := `
 SELECT

--- a/model/db.go
+++ b/model/db.go
@@ -32,6 +32,7 @@ func WipeDatabase(db *sqlx.DB) {
 	db.MustExec(`DROP TABLE IF EXISTS circle_members`)
 	db.MustExec(`DROP TABLE IF EXISTS fb_pages`)
 	db.MustExec(`DROP TABLE IF EXISTS fb_events`)
+	db.MustExec(`DROP TABLE IF EXISTS discord_users`)
 
 	db.MustExec(`
 CREATE TABLE activists (
@@ -257,6 +258,15 @@ CREATE TABLE fb_events (
   is_canceled TINYINT NOT NULL DEFAULT '0',
   last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (id, page_id)
+)
+`)
+
+	db.MustExec(`
+CREATE TABLE discord_users (
+  id BIGINT(18) PRIMARY KEY,
+  email VARCHAR(200) NOT NULL,
+  token VARCHAR(64) NOT NULL,
+  confirmed TINYINT(1) NOT NULL DEFAULT '0'
 )
 `)
 

--- a/model/discord.go
+++ b/model/discord.go
@@ -16,8 +16,8 @@ type DiscordUserStatus string
 
 const (
 	NotFound  DiscordUserStatus = "not found"
-	Pending                     = "pending"
-	Confirmed                   = "confirmed"
+	Pending   DiscordUserStatus = "pending"
+	Confirmed DiscordUserStatus = "confirmed"
 )
 
 func InsertOrUpdateDiscordUser(db *sqlx.DB, user DiscordUser) error {
@@ -51,10 +51,10 @@ func GetDiscordUserStatus(db *sqlx.DB, id int) (DiscordUserStatus, error) {
 	return NotFound, nil
 }
 
-func ConfirmDiscordUser(db *sqlx.DB, user DiscordUser) (bool, error) {
+func ConfirmDiscordUser(db *sqlx.DB, user DiscordUser) error {
 	_, err := db.NamedExec(`UPDATE discord_users SET confirmed = 1 WHERE id = :id AND token = :token`, user)
 	if err != nil {
-		return false, err
+		return err
 	}
-	return true, nil
+	return nil
 }

--- a/model/discord.go
+++ b/model/discord.go
@@ -1,0 +1,60 @@
+package model
+
+import (
+	"github.com/jmoiron/sqlx"
+	"github.com/pkg/errors"
+)
+
+type DiscordUser struct {
+	ID        int    `db:"id"`
+	Email     string `db:"email"`
+	Token     string `db:"token"`
+	Confirmed bool   `db:"confirmed"`
+}
+
+type DiscordUserStatus string
+
+const (
+	NotFound  DiscordUserStatus = "not found"
+	Pending                     = "pending"
+	Confirmed                   = "confirmed"
+)
+
+func InsertOrUpdateDiscordUser(db *sqlx.DB, user DiscordUser) error {
+	_, err := db.NamedExec(`REPLACE INTO discord_users ( id, email, token )
+		VALUES ( :id, :email, :token )`, user)
+	if err != nil {
+		return errors.Wrapf(err, "failed to insert or update user %d", user.ID)
+	}
+	return nil
+}
+
+func GetDiscordUserStatus(db *sqlx.DB, id int) (DiscordUserStatus, error) {
+	query := `SELECT id, email, token, confirmed
+		FROM discord_users
+		WHERE id = ?`
+	var users []DiscordUser
+	err := db.Select(&users, query, id)
+	if err != nil {
+		return NotFound, errors.Wrap(err, "failed to select user")
+	}
+	if len(users) > 1 {
+		return NotFound, errors.New("found too many users")
+	}
+	if len(users) == 1 {
+		if users[0].Confirmed {
+			return Confirmed, nil
+		} else {
+			return Pending, nil
+		}
+	}
+	return NotFound, nil
+}
+
+func ConfirmDiscordUser(db *sqlx.DB, user DiscordUser) (bool, error) {
+	_, err := db.NamedExec(`UPDATE discord_users SET confirmed = 1 WHERE id = :id AND token = :token`, user)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/templates/discord.html
+++ b/templates/discord.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+    <meta name="csrf-token" content="{{ .CsrfField }}">
+    <title>Activist Database</title>
+    <link rel="icon" type="image/png"
+     href="/static/img/favicon.png" />
+
+    <link href="/static/external/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" type="text/css" href="/static/css/style.css?{{ .StaticResourcesHash }}">
+    <script src="/static/external/jquery-3.2.1.js"></script>
+    <script src="/static/external/bootstrap/js/bootstrap.min.js"></script>
+
+    <style>
+      a {
+        color: black;
+      }
+      a:hover {
+        color: blue;
+      }
+    </style>
+  </head>
+  <body>
+
+    <div class="body-wrapper">
+      <h1>{{ .PageName }}</h1>
+      <div>{{ .Data.message }}</div>
+      <br />
+      <a class="btn btn-primary" type="submit" href="https://discord.com/login">Return to Discord</a>
+      <br />
+    </div>
+
+  </body>
+</html>


### PR DESCRIPTION
The idea behind this is to verify people's email address when they join the DxE Discord server, so that we can link their Discord ID to their activist record in the ADB.

The Discord bot (a separate node.js app) will message people when they join the server & hit these ADB endpoints to handle the user confirmation flow.