### PR TITLE
fix "prod" flag bug

### DIFF
--- a/adb-forms/processor/config.go
+++ b/adb-forms/processor/config.go
@@ -1,7 +1,6 @@
 package processor
 
 import (
-	"flag"
 	"github.com/dxe/adb/config"
 	"github.com/rs/zerolog/log"
 	"strconv"
@@ -26,7 +25,7 @@ type sendLogByEmailEnv struct {
 
 func getMainEnv(logLevel int) (mainEnv, bool) {
 	var emptyMainEnv mainEnv
-	if !isFlagPassed("logLevel") {
+	if !config.IsFlagPassed("logLevel") {
 		envLogLevel, ok := parseUint64(config.FormProcessorLogLevel)
 		if !ok {
 			return emptyMainEnv, false
@@ -70,14 +69,4 @@ func parseUint64(value string) (uint64, bool) {
 		return 0, false
 	}
 	return parsed, true
-}
-
-func isFlagPassed(name string) bool {
-	found := false
-	flag.Visit(func(f *flag.Flag) {
-		if f.Name == name {
-			found = true
-		}
-	})
-	return found
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"flag"
 	"math/rand"
 	"os"
 	"strconv"
@@ -16,7 +17,7 @@ var (
 	Port    = mustGetenv("PORT", "8080", true)
 	UrlPath = mustGetenv("ADB_URL_PATH", "http://localhost:"+Port, true)
 
-	IsProd            = mustGetenvAsBool("PROD")
+	IsProd            = getIsProd()
 	RunBackgroundJobs = mustGetenvAsBool("RUN_BACKGROUND_JOBS")
 
 	CookieSecret = mustGetenv("COOKIE_SECRET", "some-fake-secret", true)
@@ -96,6 +97,14 @@ var (
 	)
 )
 
+func getIsProd() bool {
+	var isProd = flag.Bool("prod", false, "whether to run as production")
+	if !IsFlagPassed("prod") {
+		*isProd = mustGetenvAsBool("PROD")
+	}
+	return *isProd
+}
+
 func mustGetenv(key, fallback string, mandatory bool) string {
 	val := os.Getenv(key)
 	if val != "" {
@@ -138,4 +147,14 @@ var staticResourcesHash = strconv.FormatInt(rand.NewSource(time.Now().UnixNano()
 // for now.
 func StaticResourcesHash() string {
 	return staticResourcesHash
+}
+
+func IsFlagPassed(name string) bool {
+	found := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			found = true
+		}
+	})
+	return found
 }

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/csv"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"html/template"
 	"io"
@@ -18,14 +19,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dxe/adb/mailer"
-
 	oidc "github.com/coreos/go-oidc"
 	"github.com/dxe/adb/adb-forms/processor"
 	"github.com/dxe/adb/config"
 	"github.com/dxe/adb/discord"
 	"github.com/dxe/adb/event_sync"
 	"github.com/dxe/adb/google_groups_sync"
+	"github.com/dxe/adb/mailer"
 	"github.com/dxe/adb/members"
 	"github.com/dxe/adb/model"
 	"github.com/dxe/adb/survey_mailer"
@@ -2060,7 +2060,7 @@ func (c MainController) InternationalFormHandler(w http.ResponseWriter, r *http.
 }
 
 func main() {
-
+	flag.Parse()
 	fmt.Println("IsProd =", config.IsProd)
 
 	n := negroni.New()


### PR DESCRIPTION
Add `prod` as a flag for the Go application to fix the "flag provided but not defined: -prod" bug that appeared when adding the `FORM_PROCESSOR_LOG_LEVEL` flag.