### PR TITLE
[Form Processor] standardize logs

### DIFF
--- a/form_processor/functions.go
+++ b/form_processor/functions.go
@@ -9,7 +9,7 @@ import (
 func getResponsesToProcess(db *sqlx.DB, query string) ([]int, bool) {
 	rawApplicationIds, getApplicationIdsErr := db.Query(query)
 	if getApplicationIdsErr != nil {
-		log.Error().Msgf("failde to get applicationIds: %s", getApplicationIdsErr)
+		log.Error().Msgf("failed to get applicationIds: %s", getApplicationIdsErr)
 		return nil, false
 	}
 	defer rawApplicationIds.Close()
@@ -44,8 +44,7 @@ func getEmail(db *sqlx.DB, query string, id int) (string, bool) {
 	var email string
 	err := db.QueryRow(query, id).Scan(&email)
 	if err != nil {
-		log.Error().Msg("failed to find requested ID in requested table")
-		log.Error().Msgf("failed to get email for %d; %s", id, err)
+		log.Error().Msgf("failed to get email for %d; (failed to find requested ID in requested table) %s", id, err)
 		return "", false
 	}
 	return email, true

--- a/form_processor/functions.go
+++ b/form_processor/functions.go
@@ -9,7 +9,7 @@ import (
 func getResponsesToProcess(db *sqlx.DB, query string) ([]int, bool) {
 	rawApplicationIds, getApplicationIdsErr := db.Query(query)
 	if getApplicationIdsErr != nil {
-		log.Error().Msgf("error getting applicationIds: %s", getApplicationIdsErr)
+		log.Error().Msgf("failde to get applicationIds: %s", getApplicationIdsErr)
 		return nil, false
 	}
 	defer rawApplicationIds.Close()
@@ -18,7 +18,7 @@ func getResponsesToProcess(db *sqlx.DB, query string) ([]int, bool) {
 		var applicationId int
 		err := rawApplicationIds.Scan(&applicationId)
 		if err != nil {
-			log.Error().Msgf("error scanning applicationIds: %s", err)
+			log.Error().Msgf("failed to scan applicationIds: %s", err)
 			return nil, false
 		}
 		applicationIds = append(applicationIds, applicationId)
@@ -30,11 +30,11 @@ func getProcessingStatus(db *sqlx.DB, query string, id int) (bool, bool) {
 	var processed bool
 	err := db.QueryRow(query, id).Scan(&processed)
 	if err == sql.ErrNoRows {
-		log.Error().Msgf("Could not find requested ID in requested table")
+		log.Error().Msgf("failed to find requested ID in requested table")
 		return false, false
 	}
 	if err != nil {
-		log.Error().Msgf("ERROR checking processing status for %d; %s", id, err)
+		log.Error().Msgf("failed to check processing status for %d; %s", id, err)
 		return false, false
 	}
 	return processed, true
@@ -44,8 +44,8 @@ func getEmail(db *sqlx.DB, query string, id int) (string, bool) {
 	var email string
 	err := db.QueryRow(query, id).Scan(&email)
 	if err != nil {
-		log.Error().Msg("Could not find requested ID in requested table")
-		log.Error().Msgf("ERROR getting email for %d; %s", id, err)
+		log.Error().Msg("failed to find requested ID in requested table")
+		log.Error().Msgf("failed to get email for %d; %s", id, err)
 		return "", false
 	}
 	return email, true
@@ -56,8 +56,7 @@ func countActivistsForEmail(db *sqlx.DB, email string) (int, bool) {
 	// TODO: is only getting the first row accceptable?
 	err := db.QueryRow(countActivistsForEmailQuery, email).Scan(&count)
 	if err != nil {
-		log.Error().Msg("No match found or error?")
-		log.Error().Msgf("ERROR getting email count for %s from activists tables; %s", email, err)
+		log.Error().Msgf("failed to get email count for %s from activists tables (no match found or error?); %s", email, err)
 		return 0, false
 	}
 	return count, true

--- a/form_processor/processor.go
+++ b/form_processor/processor.go
@@ -43,7 +43,7 @@ func process(db *sqlx.DB) {
 	/* Try to acquire the lock file */
 	_, getLockFileErr := os.Stat(processEnv.lockFilePath)
 	if !os.IsNotExist(getLockFileErr) {
-		log.Error().Msg("PROCESSOR_RUNNING flag found; exiting.")
+		log.Error().Msg("PROCESSOR_RUNNING flag found; exiting")
 		return
 	}
 	log.Debug().Msg("did not find lock file; will create lock file")

--- a/form_processor/processor.go
+++ b/form_processor/processor.go
@@ -36,20 +36,20 @@ func process(db *sqlx.DB) {
 	log.Debug().Msg("starting processing run")
 	processEnv, ok := getProcessEnv()
 	if !ok {
-		log.Error().Msg("failed to get ENV variables; will no start processing run")
+		log.Error().Msg("failed to get ENV variables; will not start processing run")
 		return
 	}
 
 	/* Try to acquire the lock file */
 	_, getLockFileErr := os.Stat(processEnv.lockFilePath)
 	if !os.IsNotExist(getLockFileErr) {
-		log.Error().Msg("ERROR: PROCESSOR_RUNNING flag found. Exiting.")
+		log.Error().Msg("PROCESSOR_RUNNING flag found; exiting.")
 		return
 	}
 	log.Debug().Msg("did not find lock file; will create lock file")
 	_, createLockFileErr := os.Create(processEnv.lockFilePath)
 	if createLockFileErr != nil {
-		log.Error().Msgf("error creating lock file; exiting; %s", createLockFileErr)
+		log.Error().Msgf("failed to create lock file; exiting; %s", createLockFileErr)
 		return
 	}
 	log.Debug().Msg("successfully created lock file; proceeding")
@@ -78,16 +78,16 @@ func processForms(db *sqlx.DB) {
 		return
 	}
 	if len(applicationIds) == 0 {
-		log.Debug().Msg("No new form_application submissions to process")
+		log.Debug().Msg("no new form_application submissions to process")
 	}
 	for _, id := range applicationIds {
 		log.Info().Msgf("Processing Application row %d", id)
 		_, processErr := db.Exec(processApplicationOnNameQuery, id)
 		if processErr != nil {
-			log.Error().Msgf("error processing application on name; exiting; %s", processErr)
+			log.Error().Msgf("failed to prrocess application on name; exiting; %s", processErr)
 			return
 		}
-		log.Info().Msg("Executed sql command to process Application based on name")
+		log.Info().Msg("executed sql command to process Application based on name")
 
 		processed, isSuccess := getProcessingStatus(db, applicationProcessingStatusQuery, id)
 		if !isSuccess {
@@ -117,7 +117,7 @@ func processForms(db *sqlx.DB) {
 					log.Error().Msgf("failed to processApplicationOnEmailQuery; exiting; %s", err)
 					return
 				}
-				log.Info().Msg("Executed sql command to process Application based on email")
+				log.Info().Msg("executed sql command to process Application based on email")
 			case 0:
 				// insert new record
 				ctx := context.Background()
@@ -126,14 +126,14 @@ func processForms(db *sqlx.DB) {
 					log.Error().Msgf("failed to BeginTx for processApplicationByInsertQuery; exiting; %s", txErr)
 					return
 				} else {
-					log.Info().Msg("successfully began transaction; will continue")
+					log.Info().Msg("successfully began transaction; proceeding")
 				}
 				_, processErr := tx.ExecContext(ctx, processApplicationByInsertQuery, id)
 				if processErr != nil {
 					log.Error().Msgf("failed to processApplicationByInsertQuery; exiting; %s", processErr)
 					return
 				}
-				log.Info().Msg("Executed sql command to insert new activist record from Application")
+				log.Info().Msg("executed sql command to insert new activist record from Application")
 				res, updateErr := tx.ExecContext(ctx, processApplicationByInsertUpdateQuery, id)
 				if updateErr != nil {
 					log.Error().Msgf("failed to processApplicationByInsertUpdateQuery; exiting; %s", updateErr)
@@ -152,19 +152,19 @@ func processForms(db *sqlx.DB) {
 					log.Error().Msg("the activist was not updated (application date in activists table does not match the" +
 						" date in application?); please correct")
 				} else {
-					log.Info().Msg("Executed sql command to mark as processed")
+					log.Info().Msg("executed sql command to mark Application as processed")
 				}
 				commitErr := tx.Commit()
 				if commitErr != nil {
 					log.Error().Msgf("failed to commit transaction; exiting; %s", commitErr)
 					return
 				} else {
-					log.Info().Msg("successfully committed transaction; will continue")
+					log.Info().Msg("successfully committed transaction; proceeding")
 				}
 			default:
 				// email count is > 1, so send email to tech
 				log.Error().Msgf(
-					"ERROR: %d non-hidden activists associated with email address %s for"+
+					"%d non-hidden activists associated with email address %s for"+
 						" Application response %d Please correct.",
 					count,
 					email,
@@ -181,17 +181,17 @@ func processForms(db *sqlx.DB) {
 		return
 	}
 	if len(interestIds) == 0 {
-		log.Debug().Msg("No new form_interest submissions to process")
+		log.Debug().Msg("no new form_interest submissions to process")
 	}
 	for _, id := range interestIds {
-		log.Info().Msgf("Processing Interest row %d", id)
+		log.Info().Msgf("processing Interest row %d", id)
 
 		_, processErr := db.Exec(processInterestOnNameQuery, id)
 		if processErr != nil {
-			log.Error().Msgf("error processing interest on name; exiting; %s", processErr)
+			log.Error().Msgf("failed to process interest on name; exiting; %s", processErr)
 			return
 		}
-		log.Info().Msg("Executed sql command to process Interest based on name")
+		log.Info().Msg("executed sql command to process Interest based on name")
 
 		processed, isSuccess := getProcessingStatus(db, interestProcessingStatusQuery, id)
 		if !isSuccess {
@@ -220,7 +220,7 @@ func processForms(db *sqlx.DB) {
 					log.Error().Msgf("failed to processInterestOnEmailQuery; exiting; %s", err)
 					return
 				}
-				log.Info().Msg("Executed sql command to process Interest based on email")
+				log.Info().Msg("executed sql command to process Interest based on email")
 			case 0:
 				// insert new record
 				ctx := context.Background()
@@ -229,14 +229,14 @@ func processForms(db *sqlx.DB) {
 					log.Error().Msgf("failed to BeginTx for processInterestByInsertQuery; exiting; %s", txErr)
 					return
 				} else {
-					log.Info().Msg("successfully began transaction; will continue")
+					log.Info().Msg("successfully began transaction; proceeding")
 				}
 				_, processErr := db.ExecContext(ctx, processInterestByInsertQuery, id)
 				if processErr != nil {
 					log.Error().Msgf("failed to processInterestByInsertQuery; exiting; %s", processErr)
 					return
 				}
-				log.Info().Msg("Executed sql command to insert new activist record from Interest")
+				log.Info().Msg("executed sql command to insert new activist record from Interest")
 				res, updateErr := db.ExecContext(ctx, processInsertByInsertUpdateQuery, id)
 				if updateErr != nil {
 					log.Error().Msgf("failed to processInsertByInsertUpdateQuery; exiting; %s", updateErr)
@@ -255,19 +255,19 @@ func processForms(db *sqlx.DB) {
 					log.Error().Msg("the activist was not updated (application date in activists table" +
 						" does not match the date in interest?); please correct")
 				} else {
-					log.Info().Msg("Successfully executed sql command to mark as processed")
+					log.Info().Msg("successfully executed sql command to mark Intereest as processed")
 				}
 				commitErr := tx.Commit()
 				if commitErr != nil {
 					log.Error().Msgf("failed to commit transaction; exiting; %s", commitErr)
 					return
 				} else {
-					log.Info().Msg("successfully committed transaction; will continue")
+					log.Info().Msg("successfully committed transaction; proceeding")
 				}
 			default:
 				// email count is > 1, so send email to tech
 				log.Error().Msgf(
-					"ERROR: %d non-hidden activists associated with email address %s for Interest"+
+					"%d non-hidden activists associated with email address %s for Interest"+
 						" response %d Please correct.",
 					count,
 					email,


### PR DESCRIPTION
- convert double logs into single logs
- use the same wording
- use the same punctuation
- remove duplicate info, e.g. "error"