### PR TITLE
Pin all node packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2687,8 +2687,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "pify": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -16,30 +16,30 @@
     "trailingComma": "all"
   },
   "dependencies": {
-    "awesomplete": "^1.1.5",
-    "buefy": "^0.9.7",
-    "dayjs": "^1.10.4",
-    "debounce": "^1.2.0",
-    "handsontable": "^6.2.2",
-    "serialize-javascript": "^3.1.0",
-    "uiv": "^0.28.0",
-    "vue": "^2.6.10"
+    "awesomplete": "1.1.5",
+    "buefy": "0.9.7",
+    "dayjs": "1.10.4",
+    "debounce": "1.2.0",
+    "handsontable": "6.2.2",
+    "serialize-javascript": "3.1.0",
+    "uiv": "0.28.0",
+    "vue": "2.6.10"
   },
   "devDependencies": {
-    "@types/awesomplete": "^1.1.9",
-    "@types/chosen-js": "^1.8.1",
-    "@types/debounce": "^1.2.0",
-    "@types/jquery": "^3.3.31",
-    "@types/zipcodes": "^6.1.0",
-    "css-loader": "^2.1.1",
-    "file-loader": "^3.0.1",
+    "@types/awesomplete": "1.1.9",
+    "@types/chosen-js": "1.8.1",
+    "@types/debounce": "1.2.0",
+    "@types/jquery": "3.3.31",
+    "@types/zipcodes": "6.1.0",
+    "css-loader": "2.1.1",
+    "file-loader": "3.0.1",
     "prettier": "2.3.0",
-    "style-loader": "^0.23.1",
-    "ts-loader": "^5.4.5",
-    "typescript": "^3.6.3",
-    "vue-loader": "^15.7.1",
-    "vue-template-compiler": "^2.6.10",
-    "webpack": "^4.42.0",
-    "webpack-cli": "^3.3.8"
+    "style-loader": "0.23.1",
+    "ts-loader": "5.4.5",
+    "typescript": "3.6.3",
+    "vue-loader": "15.7.1",
+    "vue-template-compiler": "2.6.10",
+    "webpack": "4.42.0",
+    "webpack-cli": "3.3.8"
   }
 }


### PR DESCRIPTION
Why: avoid unexpected differences between different environments
What: pin all node packages to their current minimum version