### PR TITLE
Do not exit on OIDC provider construction failures

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,7 @@ import (
 var (
 	DBUser     = mustGetenv("DB_USER", "adb_user", true)
 	DBPassword = mustGetenv("DB_PASSWORD", "adbpassword", true)
-	DBName     = mustGetenv("DB_NAME", "adb_testing_1", true)
+	DBName     = mustGetenv("DB_NAME", "adb_db", true)
 	DBProtocol = mustGetenv("DB_PROTOCOL", "", true)
 
 	Port        = mustGetenv("PORT", "8080", true)

--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,7 @@ import (
 var (
 	DBUser     = mustGetenv("DB_USER", "adb_user", true)
 	DBPassword = mustGetenv("DB_PASSWORD", "adbpassword", true)
-	DBName     = mustGetenv("DB_NAME", "adb_db", true)
+	DBName     = mustGetenv("DB_NAME", "adb_testing_1", true)
 	DBProtocol = mustGetenv("DB_PROTOCOL", "", true)
 
 	Port        = mustGetenv("PORT", "8080", true)

--- a/main.go
+++ b/main.go
@@ -440,7 +440,7 @@ func getUserFromContext(ctx context.Context) model.ADBUser {
 var verifier = func() *oidc.IDTokenVerifier {
 	provider, err := oidc.NewProvider(context.Background(), "https://accounts.google.com")
 	if err != nil {
-		log.Println("failed to create OIDC provider (no Internet connection)?: ", err)
+		log.Println("WARNING: failed to construct OIDC provider (no Internet connection?). Some features may not work: ", err)
 		return nil
 	}
 	return provider.Verifier(&oidc.Config{

--- a/main.go
+++ b/main.go
@@ -440,7 +440,7 @@ func getUserFromContext(ctx context.Context) model.ADBUser {
 var verifier = func() *oidc.IDTokenVerifier {
 	provider, err := oidc.NewProvider(context.Background(), "https://accounts.google.com")
 	if err != nil {
-		log.Println("WARNING: failed to construct OIDC provider (no Internet connection?). Some features may not work: ", err)
+		log.Println("WARNING: failed to construct OIDC provider (no Internet connection?). Some features may not work. Error: ", err)
 		return nil
 	}
 	return provider.Verifier(&oidc.Config{

--- a/main.go
+++ b/main.go
@@ -440,7 +440,8 @@ func getUserFromContext(ctx context.Context) model.ADBUser {
 var verifier = func() *oidc.IDTokenVerifier {
 	provider, err := oidc.NewProvider(context.Background(), "https://accounts.google.com")
 	if err != nil {
-		log.Fatal(err)
+		log.Println("failed to create OIDC provider (no Internet connection)?: ", err)
+		return nil
 	}
 	return provider.Verifier(&oidc.Config{
 		ClientID: "975059814880-lfffftbpt7fdl14cevtve8sjvh015udc.apps.googleusercontent.com",

--- a/main.go
+++ b/main.go
@@ -440,7 +440,10 @@ func getUserFromContext(ctx context.Context) model.ADBUser {
 var verifier = func() *oidc.IDTokenVerifier {
 	provider, err := oidc.NewProvider(context.Background(), "https://accounts.google.com")
 	if err != nil {
-		log.Println("WARNING: failed to construct OIDC provider (no Internet connection?). Some features may not work. Error:", err)
+		log.Println(
+			"WARNING: failed to construct OIDC provider (no Internet connection?). Some features may not work. Error:",
+			err,
+		)
 		return nil
 	}
 	return provider.Verifier(&oidc.Config{

--- a/main.go
+++ b/main.go
@@ -440,7 +440,7 @@ func getUserFromContext(ctx context.Context) model.ADBUser {
 var verifier = func() *oidc.IDTokenVerifier {
 	provider, err := oidc.NewProvider(context.Background(), "https://accounts.google.com")
 	if err != nil {
-		log.Println("WARNING: failed to construct OIDC provider (no Internet connection?). Some features may not work. Error: ", err)
+		log.Println("WARNING: failed to construct OIDC provider (no Internet connection?). Some features may not work. Error:", err)
 		return nil
 	}
 	return provider.Verifier(&oidc.Config{

--- a/members/auth.go
+++ b/members/auth.go
@@ -23,7 +23,7 @@ const (
 var conf, verifier = func() (*oauth2.Config, *oidc.IDTokenVerifier) {
 	provider, err := oidc.NewProvider(context.Background(), "https://accounts.google.com")
 	if err != nil {
-		log.Println("failed to construct OIDC provider (no Internet connection)?: ", err)
+		log.Println("WARNING: failed to construct OIDC provider (no Internet connection?). Some features may not work: ", err)
 		return nil, nil
 	}
 	conf := &oauth2.Config{

--- a/members/auth.go
+++ b/members/auth.go
@@ -23,7 +23,7 @@ const (
 var conf, verifier = func() (*oauth2.Config, *oidc.IDTokenVerifier) {
 	provider, err := oidc.NewProvider(context.Background(), "https://accounts.google.com")
 	if err != nil {
-		log.Println("WARNING: failed to construct OIDC provider (no Internet connection?). Some features may not work: ", err)
+		log.Println("WARNING: failed to construct OIDC provider (no Internet connection?). Some features may not work. Error: ", err)
 		return nil, nil
 	}
 	conf := &oauth2.Config{

--- a/members/auth.go
+++ b/members/auth.go
@@ -23,7 +23,10 @@ const (
 var conf, verifier = func() (*oauth2.Config, *oidc.IDTokenVerifier) {
 	provider, err := oidc.NewProvider(context.Background(), "https://accounts.google.com")
 	if err != nil {
-		log.Println("WARNING: failed to construct OIDC provider (no Internet connection?). Some features may not work. Error: ", err)
+		log.Println(
+			"WARNING: failed to construct OIDC provider (no Internet connection?). Some features may not work. Error:",
+			err,
+		)
 		return nil, nil
 	}
 	conf := &oauth2.Config{

--- a/members/auth.go
+++ b/members/auth.go
@@ -23,7 +23,8 @@ const (
 var conf, verifier = func() (*oauth2.Config, *oidc.IDTokenVerifier) {
 	provider, err := oidc.NewProvider(context.Background(), "https://accounts.google.com")
 	if err != nil {
-		log.Fatal(err)
+		log.Println("failed to construct OIDC provider (no Internet connection)?: ", err)
+		return nil, nil
 	}
 	conf := &oauth2.Config{
 		ClientID:     config.MembersClientID,


### PR DESCRIPTION
Why: be able to work on more parts of the application while offline
What: do not exit on OIDC provider construction failures. Log a warning instead.