### PR TITLE
Remove file lock concept from form processor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ dist
 docker-compose.yml
 node_modules
 npm-debug.log
-output/

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,6 @@ COPY static static/
 COPY templates templates/
 COPY --from=build-api /src/adb ./
 COPY --from=build-ui /src/dist dist/
-RUN mkdir output/
-RUN chown -R adb output/
 
 USER adb
 

--- a/form_processor/README.md
+++ b/form_processor/README.md
@@ -56,7 +56,3 @@ Various forms for getting data into the ADB.
 ### Inserting a new activist from the application or interest form
 - All data from the form submission should be added to the new activist record.
 - " (inserted by application, check for duplicate)" should be appended to the activist's name so that someone can merge the record later if it is a duplicate of someone else whose name or email didn't match.
-
-### Logging
-- The form processor keeps a log that we can check.
-- Currently, the log is emailed daily to check for errors. It would be better if it only sent an email if an error occurs. Lately, there have been approx 2 errors per month (usually duplicate key issues).

--- a/form_processor/config.go
+++ b/form_processor/config.go
@@ -6,29 +6,14 @@ import (
 
 type mainEnv struct {
 	logLevel                   int // Use command-line argument value if it exists. Use ENV value otherwise.
-	logFilePath                string
 	processFormsCronExpression string
-}
-
-type processEnv struct {
-	logFilePath  string
-	lockFilePath string
 }
 
 func getMainEnv() (mainEnv, bool) {
 	return mainEnv{
 			logLevel:                   config.LogLevel,
-			logFilePath:                config.FormProcessorLogFilePath,
 			processFormsCronExpression: config.FormProcessorProcessFormsCronExpression,
 		},
 		true
 
-}
-
-func getProcessEnv() (processEnv, bool) {
-	return processEnv{
-			logFilePath:  config.FormProcessorLogFilePath,
-			lockFilePath: config.FormProcessorLockFilePath,
-		},
-		true
 }

--- a/form_processor/processor.go
+++ b/form_processor/processor.go
@@ -7,7 +7,6 @@ import (
 	"github.com/robfig/cron/v3"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	"os"
 )
 
 // Should be run in a goroutine.

--- a/form_processor/processor.go
+++ b/form_processor/processor.go
@@ -28,45 +28,13 @@ func StartFormProcessor(db *sqlx.DB) {
 
 	/* Start tasks on a scheduule */
 	cron := cron.New()
-	cron.AddFunc(mainEnv.processFormsCronExpression, func() { process(db) })
+	cron.AddFunc(mainEnv.processFormsCronExpression, func() { processForms(db) })
 	cron.Run()
 }
 
-func process(db *sqlx.DB) {
-	log.Debug().Msg("starting processing run")
-	processEnv, ok := getProcessEnv()
-	if !ok {
-		log.Error().Msg("failed to get ENV variables; will not start processing run")
-		return
-	}
-
-	/* Try to acquire the lock file */
-	_, getLockFileErr := os.Stat(processEnv.lockFilePath)
-	if !os.IsNotExist(getLockFileErr) {
-		log.Error().Msg("PROCESSOR_RUNNING flag found; exiting")
-		return
-	}
-	log.Debug().Msg("did not find lock file; will create lock file")
-	_, createLockFileErr := os.Create(processEnv.lockFilePath)
-	if createLockFileErr != nil {
-		log.Error().Msgf("failed to create lock file; exiting; %s", createLockFileErr)
-		return
-	}
-	log.Debug().Msg("successfully created lock file; proceeding")
-
-	/* Process form applications */
-	processForms(db)
-
-	/* Remove lock file */
-	removeLockFilErr := os.Remove(processEnv.lockFilePath)
-	if removeLockFilErr != nil {
-		log.Error().Msgf("failed to remove lock file: %s", removeLockFilErr)
-	}
-
-	log.Debug().Msg("finished processing run")
-}
-
 func processForms(db *sqlx.DB) {
+	log.Debug().Msg("starting processing run")
+
 	/* Get form applications to process */
 	applicationIds, isSuccess := getResponsesToProcess(db, applicationResponsesToProcessQuery)
 	if !isSuccess {
@@ -272,4 +240,6 @@ func processForms(db *sqlx.DB) {
 			}
 		}
 	}
+
+	log.Debug().Msg("finished processing run")
 }


### PR DESCRIPTION
Why: there is no need to have a lock file anymore since the application is Dockerized so there won't be multiple processes competing for the same lock file
What: remove anything that was based on the concept of having a lock file from the codebase