### PR TITLE
Log out after 12 hours

### DIFF
--- a/main.go
+++ b/main.go
@@ -140,9 +140,8 @@ func setAuthSession(w http.ResponseWriter, r *http.Request, adbUser model.ADBUse
 	}
 	authSession.Options = &sessions.Options{
 		Path: "/",
-		// MaxAge is 30 days in seconds
-		MaxAge: 30 * // days
-			24 * // hours
+		// MaxAge is 12 hours in seconds
+		MaxAge: 12 * // hours
 			60 * // minutes
 			60, // seconds
 		HttpOnly: true,


### PR DESCRIPTION
After a Google account is disabled or password reset, we need ADB access to expire in less than 30 days which is the current behavior. However, this change avoids expiring the session too quickly in order to avoid data loss until we can set up sessions to renew automatically before they expire if the user is still working or verify this is already happening.