### PR TITLE
Fix misplaced City dropdown on dxe.io/join

### DIFF
--- a/frontend/FormInternational.vue
+++ b/frontend/FormInternational.vue
@@ -63,6 +63,9 @@
           >
           </vue-google-autocomplete>
         </b-field>
+        <p style="font-size: small; font-style: italic" v-if="!this.locationChosen">
+          Please make a selection in the dropdown list that appears here as you type a city name.
+        </p>
       </div>
 
       <div class="column is-full">

--- a/frontend/external/vue-google-autocomplete/src/VueGoogleAutocomplete.vue
+++ b/frontend/external/vue-google-autocomplete/src/VueGoogleAutocomplete.vue
@@ -186,6 +186,28 @@ export default {
     this.autocomplete.setFields(this.fields);
 
     this.autocomplete.addListener('place_changed', this.onPlaceChanged);
+
+    // Browser autocomplete interferes with the defining autocomplete
+    // feature that this component provides.
+    //
+    // The dropdown list of locations does not show unless the user types
+    // something, and browser autocomplete may prevent the user from typing
+    // since the field may already be populated with a text value that looks
+    // correct. However, the user needs to select a location from the dropdown,
+    // so we do need them to type something.
+    //
+    // autocomplete="off" doesn't work in Chrome as of Feb 27, 2025 (even though the
+    // app is HTML5). autocomplete="x" or any other unrecognized value does seem
+    // to prevent at least Chrome's autocomplete.
+    //
+    // Setting attribute directly in the Vue template does not work.
+    // Without setTimeout, this does not work. Using $nextTick instead of
+    // setTimeout also does not work. These other attempts result in the
+    // attribute always being set to "off", which does not have the desired
+    // effect as mentioned above.
+    setTimeout(() => {
+      this.$refs.autocomplete.setAttribute('autocomplete', 'some-unrecognized-value-xf4p');
+    }, 100);
   },
 
   methods: {

--- a/frontend/static/css/style.css
+++ b/frontend/static/css/style.css
@@ -1,11 +1,8 @@
 /* global styles */
 html,
 body {
-  height: 100%;
-  overflow: auto;
-}
-body {
-  background: linear-gradient(rgba(80, 90, 170, 0.85), rgba(80, 90, 170, 0.85)),
+  background:
+    linear-gradient(rgba(80, 90, 170, 0.85), rgba(80, 90, 170, 0.85)),
     url('/static/img/bg1.jpg') no-repeat center center fixed;
   -webkit-background-size: cover;
   -moz-background-size: cover;
@@ -31,7 +28,9 @@ h1.title {
   background-color: white;
   padding: 25px 40px 25px 40px;
   margin: 0 auto;
-  box-shadow: 0 12px 16px 0 rgba(0, 0, 0, 0.24), 0 17px 50px 0 rgba(0, 0, 0, 0.19);
+  box-shadow:
+    0 12px 16px 0 rgba(0, 0, 0, 0.24),
+    0 17px 50px 0 rgba(0, 0, 0, 0.19);
   opacity: 0.98;
 }
 


### PR DESCRIPTION
Previously, the City field autocomplete dropdown would be positioned correctly only if the user did not scroll from the top of the page, a known issue with vue-google-autocomplete:
https://github.com/MadimetjaShika/vuetify-google-autocomplete/issues/100

On small screens, if the "City" field was "below the fold", the dropdown would be hidden entirely.

The issue is fixed by removing "overflow: auto" on html/body, which was added here:
https://github.com/dxe/adb/commit/ae799dcf1795c20fed7a3dd3aefd60bfc9db5542#diff-a5ea33c888430601a659bcbef2da1944097953737f2606282efc13ca6e5fbabaR2

After removing overflow: auto, white margins appeared above and below the background image. Removing the duplicate body CSS rule fixed this. Removing "height: 100%" fixed something else that started happening too. As far as I can tell, the app works the same as before with all of these changes combined.

Not sure if a new version of vue-google-autocomplete would fix it but anyway we can't upgrade to the latest version because it requires upgrading Vue to at least 2.7.