### PR TITLE
Fix "webpack watch" in debugger config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,8 @@
       "skipFiles": ["<node_internals>/**"],
       "type": "node",
       "runtimeVersion": "16",
+      // Webpack watch only shows build status when TTY is detected
+      "console": "integratedTerminal",
     },
     {
       "name": "Launch React Frontend",


### PR DESCRIPTION
Wasn't showing build status; made it hard to know when to refresh the page to see recent changes.