### PR TITLE
Undo navigation bug on event list page

### DIFF
--- a/server/templates/event_list.html
+++ b/server/templates/event_list.html
@@ -1,12 +1,7 @@
 {{template "header.html" .}}
 
 <div id="app">
-  <adb-nav
-    page="{{ .PageName }}"
-    user="{{ .UserName }}"
-    role="admin"
-    chapter="{{ .UserChapter.Name }}"
-  ></adb-nav>
+  <adb-nav page="{{ .PageName }}" user="{{ .UserName }}" role="{{ .MainRole }}" chapter="{{ .UserChapter.Name }}"></adb-nav>
   <event-list></event-list>
 </div>
 <script src="/dist/adb.js?{{ .StaticResourcesHash }}"></script>


### PR DESCRIPTION
It was showing the navigation as if the user was always an admin. Introduced here, probably for testing: https://github.com/dxe/adb/commit/f02c797c0224d0076e84ebc2ebe6a4d68c2ef104#diff-cb8123a015cec42248e9e3799392ad0185efe8c5b725d024ca068afa333181c5L4