### PR TITLE
feat: add timestamp columns to activists

### DIFF
--- a/server/scripts/db-migrations/20250810034041_activist_timestamps.down.sql
+++ b/server/scripts/db-migrations/20250810034041_activist_timestamps.down.sql
@@ -3,5 +3,4 @@ ALTER TABLE activists
     DROP COLUMN phone_updated,
     DROP COLUMN email_updated,
     DROP COLUMN address_updated,
-    DROP COLUMN location_updated,
-    DROP COLUMN coords_updated;
+    DROP COLUMN location_updated;

--- a/server/scripts/db-migrations/20250810034041_activist_timestamps.down.sql
+++ b/server/scripts/db-migrations/20250810034041_activist_timestamps.down.sql
@@ -3,4 +3,5 @@ ALTER TABLE activists
     DROP COLUMN phone_updated,
     DROP COLUMN email_updated,
     DROP COLUMN address_updated,
+    DROP COLUMN location_updated,
     DROP COLUMN coords_updated;

--- a/server/scripts/db-migrations/20250810034041_activist_timestamps.down.sql
+++ b/server/scripts/db-migrations/20250810034041_activist_timestamps.down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE activists
+    DROP COLUMN created,
+    DROP COLUMN phone_updated,
+    DROP COLUMN email_updated,
+    DROP COLUMN address_updated,
+    DROP COLUMN coords_updated;

--- a/server/scripts/db-migrations/20250810034041_activist_timestamps.up.sql
+++ b/server/scripts/db-migrations/20250810034041_activist_timestamps.up.sql
@@ -1,0 +1,22 @@
+-- *_updated timestamps may be used to resolve conflicts when merging activist records
+
+-- A sentinel value is used as the default in order to indicate unknown modification times for
+-- existing table rows in production.
+ALTER TABLE activists
+    ADD COLUMN created TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:01',
+    ADD COLUMN phone_updated TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:01',
+    ADD COLUMN email_updated TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:01',
+    ADD COLUMN address_updated TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:01',
+    ADD COLUMN coords_updated TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:01';
+
+-- Change default for new records to CURRENT_TIMESTAMP.
+ALTER TABLE activists
+    MODIFY COLUMN created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE activists
+    MODIFY COLUMN phone_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE activists
+    MODIFY COLUMN email_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE activists
+    MODIFY COLUMN address_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE activists
+    MODIFY COLUMN coords_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/server/scripts/db-migrations/20250810034041_activist_timestamps.up.sql
+++ b/server/scripts/db-migrations/20250810034041_activist_timestamps.up.sql
@@ -10,13 +10,15 @@ ALTER TABLE activists
     -- Time that email was last changed or confirmed, or sentinel value if unknown.
     ADD COLUMN email_updated TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:01',
     -- Time that street, city or state was last changed or confirmed, or sentinel value if unknown.
+    -- Also indicates when lat, lng coordinates are updated, as they are computed from the address.
     ADD COLUMN address_updated TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:01',
-    -- Time that the zip code, street, city or state was last changed or confirmed, or sentinel value if unknown.
+    -- Time that any address field (street, city, state) or the 'location' field was last changed or confirmed, or
+    -- sentinel value if unknown.
     -- location_updated may be updated separately from address_updated, e.g. when we receive only a zip code from a
     -- petition which may not match the activist's existing street / city / state.
-    ADD COLUMN location_updated TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:01',
-    -- Time that coordinates were last changed or confirmed, or sentinel value if unknown.
-    ADD COLUMN coords_updated TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:01';
+    -- It is updated when the address is updated because it is assumed that the process or user who updates the address
+    -- will also verify the location field is up to date as well.
+    ADD COLUMN location_updated TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:01';
 
 -- Change default for new records to CURRENT_TIMESTAMP.
 ALTER TABLE activists
@@ -29,5 +31,3 @@ ALTER TABLE activists
     MODIFY COLUMN address_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
 ALTER TABLE activists
     MODIFY COLUMN location_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
-ALTER TABLE activists
-    MODIFY COLUMN coords_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/server/scripts/db-migrations/20250810034041_activist_timestamps.up.sql
+++ b/server/scripts/db-migrations/20250810034041_activist_timestamps.up.sql
@@ -3,10 +3,19 @@
 -- A sentinel value is used as the default in order to indicate unknown modification times for
 -- existing table rows in production.
 ALTER TABLE activists
+    -- Time when the record was created, or sentinel value if unknown.
     ADD COLUMN created TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:01',
+    -- Time that phone number was last changed or confirmed, or sentinel value if unknown.
     ADD COLUMN phone_updated TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:01',
+    -- Time that email was last changed or confirmed, or sentinel value if unknown.
     ADD COLUMN email_updated TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:01',
+    -- Time that street, city or state was last changed or confirmed, or sentinel value if unknown.
     ADD COLUMN address_updated TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:01',
+    -- Time that the zip code, street, city or state was last changed or confirmed, or sentinel value if unknown.
+    -- location_updated may be updated separately from address_updated, e.g. when we receive only a zip code from a
+    -- petition which may not match the activist's existing street / city / state.
+    ADD COLUMN location_updated TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:01',
+    -- Time that coordinates were last changed or confirmed, or sentinel value if unknown.
     ADD COLUMN coords_updated TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:01';
 
 -- Change default for new records to CURRENT_TIMESTAMP.
@@ -18,5 +27,7 @@ ALTER TABLE activists
     MODIFY COLUMN email_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
 ALTER TABLE activists
     MODIFY COLUMN address_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE activists
+    MODIFY COLUMN location_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
 ALTER TABLE activists
     MODIFY COLUMN coords_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/server/src/form_processor/application_form_processor.go
+++ b/server/src/form_processor/application_form_processor.go
@@ -13,15 +13,7 @@ import (
 
 const applicationProcessingStatusQuery = "SELECT processed FROM form_application WHERE id = ?"
 
-const processApplicationOnNameQuery = `
-# try to match on name
-UPDATE
-	activists
-INNER JOIN
-	form_application ON activists.name = form_application.name
-SET
-	activists.email_updated = IF(activists.email = '', NOW(), activists.email_updated), -- This line must precede setting activists.email
-	activists.email = IF(activists.email = '', form_application.email, activists.email),
+const applicationUpdateAssignments = `
 	activists.phone_updated = IF(activists.phone = '', NOW(), activists.phone_updated), -- This line must precede setting activists.phone
 	activists.phone = IF(activists.phone = '', form_application.phone, activists.phone),
 	activists.location_updated = IF(activists.location = '', NOW(), activists.location_updated), -- This line must precede setting activists.location
@@ -45,14 +37,30 @@ SET
 	activists.accessibility = IF(LENGTH(form_application.accessibility), form_application.accessibility, activists.accessibility),
 	# mark as processed
 	form_application.processed = 1
-WHERE
-    chapter_id = ` + model.SFBayChapterIdStr + `
+`
+
+const applicationUpdateConditions = `
+	chapter_id = ` + model.SFBayChapterIdStr + `
 	and form_application.id = ?
 	and form_application.name <> ''
 	and form_application.processed = 0
 	and activists.hidden = 0
-	and form_application.name <> '';
 `
+
+const processApplicationOnNameQuery = `
+# try to match on name
+UPDATE
+	activists
+INNER JOIN
+	form_application ON activists.name = form_application.name
+SET
+	activists.email_updated = IF(activists.email = '', NOW(), activists.email_updated), -- This line must precede setting activists.email
+	activists.email = IF(activists.email = '', form_application.email, activists.email),
+	` + applicationUpdateAssignments + `
+WHERE
+    ` + applicationUpdateConditions + `
+	AND form_application.name <> ''
+;`
 
 const processApplicationOnEmailQuery = `
 # try to match on email
@@ -61,37 +69,11 @@ UPDATE
 INNER JOIN
 	form_application ON activists.email = form_application.email
 SET
-    activists.phone_updated = IF(activists.phone = '', NOW(), activists.phone_updated), -- This line must precede setting activists.phone
-	activists.phone = IF(activists.phone = '', form_application.phone, activists.phone),
-	activists.location_updated = IF(activists.location = '', NOW(), activists.location_updated), -- This line must precede setting activists.location
-	activists.location = IF(activists.location = '', form_application.zip, activists.location),
-	activists.pronouns = IF(activists.pronouns = '', form_application.pronouns, activists.pronouns),
-	activists.dob = IF(activists.dob = '', form_application.birthday, activists.dob),
-	# check proper prospect boxes based on application type
-	activists.prospect_organizer = IF(form_application.application_type = 'organizer', 1, (IF((form_application.application_type = 'senior-organizer' and activist_level <> 'organizer'), 1, activists.prospect_organizer))),
-	activists.prospect_chapter_member = IF(form_application.application_type = 'chapter-member', 1, (IF((form_application.application_type in ('senior-organizer','organizer') and activist_level in ('supporter','circle member','non-local')), 1, activists.prospect_chapter_member))),
-	activists.circle_agreement = IF(form_application.application_type = 'circle-member', 1, activists.circle_agreement),
-	activists.circle_interest = IF(activists.id NOT in (select activist_id from working_group_members UNION select activist_id from circle_members), 1, activists.circle_interest),
-	# update application date & type
-	activists.dev_application_date = form_application.timestamp,
-	activists.dev_application_type = form_application.application_type,
-	# only update the following columns if the new values are not empty
-	activists.dev_interest = CONCAT_WS(', ', IF(LENGTH(dev_interest),dev_interest,NULL), IF(LENGTH(form_application.circle_interest),form_application.circle_interest,NULL), IF(LENGTH(wg_interest),wg_interest,NULL), IF(LENGTH(committee_interest),committee_interest,NULL)),
-	activists.referral_friends = IF(LENGTH(form_application.referral_friends), form_application.referral_friends, activists.referral_friends),
-	activists.referral_apply = IF(LENGTH(form_application.referral_apply), CONCAT_WS(', ', IF(LENGTH(activists.referral_apply),activists.referral_apply,NULL),form_application.referral_apply), activists.referral_apply),
-	activists.referral_outlet = IF(LENGTH(form_application.referral_outlet), form_application.referral_outlet, activists.referral_outlet),
-	activists.language = IF(LENGTH(form_application.language), form_application.language, activists.language),
-	activists.accessibility = IF(LENGTH(form_application.accessibility), form_application.accessibility, activists.accessibility),
-	# mark as processed
-	form_application.processed = 1
+    ` + applicationUpdateAssignments + `
 WHERE
-    chapter_id = ` + model.SFBayChapterIdStr + `
-	and form_application.id = ?
-	and form_application.name <> ''
-	and form_application.processed = 0
-	and activists.hidden = 0
-	and form_application.email <> '';
-`
+    ` + applicationUpdateConditions + `
+	AND form_application.email <> ''
+;`
 
 const processApplicationByInsertQuery = `
 # insert new records

--- a/server/src/form_processor/application_form_processor.go
+++ b/server/src/form_processor/application_form_processor.go
@@ -61,9 +61,11 @@ UPDATE
 INNER JOIN
 	form_application ON activists.email = form_application.email
 SET
+    activists.phone_updated = IF(activists.phone = '', NOW(), activists.phone_updated), -- This line must precede setting activists.phone
 	activists.phone = IF(activists.phone = '', form_application.phone, activists.phone),
-	activists.pronouns = IF(activists.pronouns = '', form_application.pronouns, activists.pronouns),
+	activists.location_updated = IF(activists.location = '', NOW(), activists.location_updated), -- This line must precede setting activists.location
 	activists.location = IF(activists.location = '', form_application.zip, activists.location),
+	activists.pronouns = IF(activists.pronouns = '', form_application.pronouns, activists.pronouns),
 	activists.dob = IF(activists.dob = '', form_application.birthday, activists.dob),
 	# check proper prospect boxes based on application type
 	activists.prospect_organizer = IF(form_application.application_type = 'organizer', 1, (IF((form_application.application_type = 'senior-organizer' and activist_level <> 'organizer'), 1, activists.prospect_organizer))),

--- a/server/src/form_processor/application_form_processor.go
+++ b/server/src/form_processor/application_form_processor.go
@@ -13,6 +13,8 @@ import (
 
 const applicationProcessingStatusQuery = "SELECT processed FROM form_application WHERE id = ?"
 
+const applicationFormEmailSqlExpr = "IF(activists.email = '', form_application.email, activists.email)"
+const applicationFormPhoneSqlExpr = "IF(activists.phone = '', form_application.phone, activists.phone)"
 const processApplicationOnNameQuery = `
 # try to match on name
 UPDATE
@@ -20,8 +22,10 @@ UPDATE
 INNER JOIN
 	form_application ON activists.name = form_application.name
 SET
-	activists.email = IF(activists.email = '', form_application.email, activists.email),
-	activists.phone = IF(activists.phone = '', form_application.phone, activists.phone),
+	activists.email = ` + applicationFormEmailSqlExpr + `,
+	activists.email_updated = IF(activists.email <> ` + applicationFormEmailSqlExpr + `, NOW(), activists.email_updated),
+	activists.phone = ` + applicationFormPhoneSqlExpr + `,
+	activists.phone_updated = IF(activists.phone <> ` + applicationFormPhoneSqlExpr + `, NOW(), activists.phone_updated),
 	activists.pronouns = IF(activists.pronouns = '', form_application.pronouns, activists.pronouns),
 	activists.location = IF(activists.location = '', form_application.zip, activists.location),
 	activists.dob = IF(activists.dob = '', form_application.birthday, activists.dob),

--- a/server/src/form_processor/application_form_processor.go
+++ b/server/src/form_processor/application_form_processor.go
@@ -13,8 +13,6 @@ import (
 
 const applicationProcessingStatusQuery = "SELECT processed FROM form_application WHERE id = ?"
 
-const applicationFormEmailSqlExpr = "IF(activists.email = '', form_application.email, activists.email)"
-const applicationFormPhoneSqlExpr = "IF(activists.phone = '', form_application.phone, activists.phone)"
 const processApplicationOnNameQuery = `
 # try to match on name
 UPDATE
@@ -22,12 +20,13 @@ UPDATE
 INNER JOIN
 	form_application ON activists.name = form_application.name
 SET
-	activists.email = ` + applicationFormEmailSqlExpr + `,
-	activists.email_updated = IF(activists.email <> ` + applicationFormEmailSqlExpr + `, NOW(), activists.email_updated),
-	activists.phone = ` + applicationFormPhoneSqlExpr + `,
-	activists.phone_updated = IF(activists.phone <> ` + applicationFormPhoneSqlExpr + `, NOW(), activists.phone_updated),
-	activists.pronouns = IF(activists.pronouns = '', form_application.pronouns, activists.pronouns),
+	activists.email_updated = IF(activists.email = '', NOW(), activists.email_updated), -- This line must precede setting activists.email
+	activists.email = IF(activists.email = '', form_application.email, activists.email),
+	activists.phone_updated = IF(activists.phone = '', NOW(), activists.phone_updated), -- This line must precede setting activists.phone
+	activists.phone = IF(activists.phone = '', form_application.phone, activists.phone),
+	activists.location_updated = IF(activists.location = '', NOW(), activists.location_updated), -- This line must precede setting activists.location
 	activists.location = IF(activists.location = '', form_application.zip, activists.location),
+	activists.pronouns = IF(activists.pronouns = '', form_application.pronouns, activists.pronouns),
 	activists.dob = IF(activists.dob = '', form_application.birthday, activists.dob),
 	# check proper prospect boxes based on application type
 	activists.prospect_organizer = IF(form_application.application_type = 'organizer', 1, (IF((form_application.application_type = 'senior-organizer' and activist_level <> 'organizer'), 1, activists.prospect_organizer))),

--- a/server/src/form_processor/application_form_processor.go
+++ b/server/src/form_processor/application_form_processor.go
@@ -223,7 +223,7 @@ func ProcessApplicationForms(db *sqlx.DB) {
 		}
 	}
 
-	log.Debug().Msg("finished processing application forms")
+	log.Info().Msg("Finished processing application forms")
 }
 
 func processApplicationForm(response formResponse, db *sqlx.DB) error {

--- a/server/src/form_processor/interest_form_processor.go
+++ b/server/src/form_processor/interest_form_processor.go
@@ -12,15 +12,7 @@ import (
 
 const interestProcessingStatusQuery = "SELECT processed FROM form_interest WHERE id = ?"
 
-const processInterestOnNameQuery = `
-# try to match on name
-UPDATE
-	activists
-INNER JOIN
-	form_interest ON activists.name = form_interest.name
-SET
-	activists.email_updated = IF(activists.email = '', NOW(), activists.email_updated), -- This line must precede setting activists.email
-	activists.email = IF(activists.email = '', form_interest.email, activists.email),
+const interestUpdateAssignments = `
 	activists.phone_updated = IF(activists.phone = '', NOW(), activists.phone_updated), -- This line must precede setting activists.phone
 	activists.phone = IF(activists.phone = '', form_interest.phone, activists.phone),
 	activists.location_updated = IF(activists.location = '', NOW(), activists.location_updated), -- This line must precede setting activists.location
@@ -39,14 +31,29 @@ SET
 	activists.discord_id = IF(LENGTH(activists.discord_id), activists.discord_id, IF(LENGTH(form_interest.discord_id), form_interest.discord_id, NULL)),
 	# mark as processed
 	form_interest.processed = 1
-
-WHERE
-    form_interest.chapter_id = activists.chapter_id
-	and form_interest.id = ?
-	and form_interest.processed = 0
-	and activists.hidden = 0
-	and form_interest.name <> '';
 `
+
+const interestUpdateConditions = `
+	form_interest.chapter_id = activists.chapter_id
+	AND form_interest.id = ?
+	AND form_interest.processed = 0
+	AND activists.hidden = 0
+`
+
+const processInterestOnNameQuery = `
+# try to match on name
+UPDATE
+	activists
+INNER JOIN
+	form_interest ON activists.name = form_interest.name
+SET
+	activists.email_updated = IF(activists.email = '', NOW(), activists.email_updated), -- This line must precede setting activists.email
+	activists.email = IF(activists.email = '', form_interest.email, activists.email),
+	` + interestUpdateAssignments + `
+WHERE
+    ` + interestUpdateConditions + `
+	AND form_interest.name <> ''
+;`
 
 const processInterestOnEmailQuery = `
 # try to match on email
@@ -55,32 +62,11 @@ UPDATE
 INNER JOIN
 	form_interest ON activists.email = form_interest.email
 SET
-	activists.phone_updated = IF(activists.phone = '', NOW(), activists.phone_updated), -- This line must precede setting activists.phone
-    activists.phone = IF(activists.phone = '', form_interest.phone, activists.phone),
-	activists.location_updated = IF(activists.location = '', NOW(), activists.location_updated), -- This line must precede setting activists.location
-	activists.location = IF(activists.location = '', form_interest.zip, activists.location),
-	# check proper prospect boxes based on application type
-	activists.circle_interest = IF(form_interest.form = 'Circle Interest Form', 1, activists.circle_interest),
-	# update interest date only if it's currently null
-	activists.interest_date = COALESCE(activists.interest_date, form_interest.timestamp),
-	# only update the following columns if the new values are not empty
-	activists.dev_interest = IFNULL(CONCAT_WS(', ', IF(LENGTH(dev_interest),dev_interest,NULL), IF(LENGTH(form_interest.interests),form_interest.interests,NULL)),''),
-	activists.referral_friends = IF(LENGTH(form_interest.referral_friends), form_interest.referral_friends, activists.referral_friends),
-	activists.referral_apply = IF(LENGTH(form_interest.referral_apply), CONCAT_WS(', ', IF(LENGTH(activists.referral_apply),activists.referral_apply,NULL),form_interest.referral_apply), activists.referral_apply),
-	activists.referral_outlet = IF(LENGTH(form_interest.referral_outlet), form_interest.referral_outlet, activists.referral_outlet),
-	# only update source if source is currently empty
-	activists.source = IF(LENGTH(activists.source), activists.source, form_interest.form),
-	activists.discord_id = IF(LENGTH(activists.discord_id), activists.discord_id, IF(LENGTH(form_interest.discord_id), form_interest.discord_id, NULL)),
-	# mark as processed
-	form_interest.processed = 1
+	` + interestUpdateAssignments + `
 WHERE
-    form_interest.chapter_id = activists.chapter_id
-	and form_interest.id = ?
-	AND form_interest.processed = 0
-	AND activists.hidden = 0
+    ` + interestUpdateConditions + `
 	AND form_interest.email <> ''
-	AND form_interest.name <> '';
-`
+;`
 
 const processInterestByInsertQuery = `
 # insert new records

--- a/server/src/form_processor/interest_form_processor.go
+++ b/server/src/form_processor/interest_form_processor.go
@@ -55,7 +55,9 @@ UPDATE
 INNER JOIN
 	form_interest ON activists.email = form_interest.email
 SET
-	activists.phone = IF(activists.phone = '', form_interest.phone, activists.phone),
+	activists.phone_updated = IF(activists.phone = '', NOW(), activists.phone_updated), -- This line must precede setting activists.phone
+    activists.phone = IF(activists.phone = '', form_interest.phone, activists.phone),
+	activists.location_updated = IF(activists.location = '', NOW(), activists.location_updated), -- This line must precede setting activists.location
 	activists.location = IF(activists.location = '', form_interest.zip, activists.location),
 	# check proper prospect boxes based on application type
 	activists.circle_interest = IF(form_interest.form = 'Circle Interest Form', 1, activists.circle_interest),

--- a/server/src/form_processor/interest_form_processor.go
+++ b/server/src/form_processor/interest_form_processor.go
@@ -12,8 +12,6 @@ import (
 
 const interestProcessingStatusQuery = "SELECT processed FROM form_interest WHERE id = ?"
 
-const interestFormEmailSqlExpr = "IF(activists.email = '', form_interest.email, activists.email)"
-const interestFormPhoneSqlExpr = "IF(activists.phone = '', form_interest.phone, activists.phone)"
 const processInterestOnNameQuery = `
 # try to match on name
 UPDATE
@@ -21,10 +19,11 @@ UPDATE
 INNER JOIN
 	form_interest ON activists.name = form_interest.name
 SET
-	activists.email = ` + interestFormEmailSqlExpr + `,
-	activists.email_updated = IF(activists.email <> ` + interestFormEmailSqlExpr + `, NOW(), activists.email_updated),
-	activists.phone = ` + interestFormPhoneSqlExpr + `,
-	activists.phone_updated = IF(activists.phone <> ` + interestFormPhoneSqlExpr + `, NOW(), activists.phone_updated),
+	activists.email_updated = IF(activists.email = '', NOW(), activists.email_updated), -- This line must precede setting activists.email
+	activists.email = IF(activists.email = '', form_interest.email, activists.email),
+	activists.phone_updated = IF(activists.phone = '', NOW(), activists.phone_updated), -- This line must precede setting activists.phone
+	activists.phone = IF(activists.phone = '', form_interest.phone, activists.phone),
+	activists.location_updated = IF(activists.location = '', NOW(), activists.location_updated), -- This line must precede setting activists.location
 	activists.location = IF(activists.location = '', form_interest.zip, activists.location),
 	# check proper prospect boxes based on application type
 	activists.circle_interest = IF(form_interest.form = 'Circle Interest Form', 1, activists.circle_interest),

--- a/server/src/form_processor/interest_form_processor.go
+++ b/server/src/form_processor/interest_form_processor.go
@@ -12,6 +12,8 @@ import (
 
 const interestProcessingStatusQuery = "SELECT processed FROM form_interest WHERE id = ?"
 
+const interestFormEmailSqlExpr = "IF(activists.email = '', form_interest.email, activists.email)"
+const interestFormPhoneSqlExpr = "IF(activists.phone = '', form_interest.phone, activists.phone)"
 const processInterestOnNameQuery = `
 # try to match on name
 UPDATE
@@ -19,8 +21,10 @@ UPDATE
 INNER JOIN
 	form_interest ON activists.name = form_interest.name
 SET
-	activists.email = IF(activists.email = '', form_interest.email, activists.email),
-	activists.phone = IF(activists.phone = '', form_interest.phone, activists.phone),
+	activists.email = ` + interestFormEmailSqlExpr + `,
+	activists.email_updated = IF(activists.email <> ` + interestFormEmailSqlExpr + `, NOW(), activists.email_updated),
+	activists.phone = ` + interestFormPhoneSqlExpr + `,
+	activists.phone_updated = IF(activists.phone <> ` + interestFormPhoneSqlExpr + `, NOW(), activists.phone_updated),
 	activists.location = IF(activists.location = '', form_interest.zip, activists.location),
 	# check proper prospect boxes based on application type
 	activists.circle_interest = IF(form_interest.form = 'Circle Interest Form', 1, activists.circle_interest),

--- a/server/src/form_processor/interest_form_processor.go
+++ b/server/src/form_processor/interest_form_processor.go
@@ -209,7 +209,7 @@ func ProcessInterestForms(db *sqlx.DB) {
 		}
 	}
 
-	log.Debug().Msg("finished processing interest forms")
+	log.Info().Msg("Finished processing interest forms")
 }
 
 func processInterestForm(response formResponse, db *sqlx.DB) error {

--- a/server/src/form_processor/interest_form_processor_test.go
+++ b/server/src/form_processor/interest_form_processor_test.go
@@ -4,17 +4,8 @@ import (
 	"testing"
 
 	"github.com/dxe/adb/model"
-	"github.com/dxe/adb/testfixtures"
 	"github.com/jmoiron/sqlx"
 )
-
-func insertActivistForInterestTest(t *testing.T, db *sqlx.DB, activist *model.ActivistExtra) {
-	id, err := model.CreateActivist(db, *activist)
-	if err != nil {
-		t.Fatalf("insertActivistForInterestTest failed: %s", err)
-	}
-	activist.ID = id
-}
 
 type interestResponseBuilder struct {
 	id        int
@@ -102,7 +93,7 @@ func TestProcessFormInterestForActivistMatchingOnName(t *testing.T) {
 	/* Set up */
 	db := useTestDb()
 	defer db.Close()
-	insertActivistForInterestTest(t, db, testfixtures.NewActivistBuilder().
+	model.MustInsertActivist(t, db, model.NewActivistBuilder().
 		WithName("Bob").
 		WithEmail("foo@example.org").
 		Build())
@@ -122,7 +113,7 @@ func TestProcessFormInterestForActivistMatchingOnEmail(t *testing.T) {
 	/* Set up */
 	db := useTestDb()
 	defer db.Close()
-	insertActivistForInterestTest(t, db, testfixtures.NewActivistBuilder().
+	model.MustInsertActivist(t, db, model.NewActivistBuilder().
 		WithName("Bob").
 		WithEmail("match@example.org").
 		Build())
@@ -142,11 +133,11 @@ func TestProcessFormInterestForMultipleMatchingActivistsOnEmail(t *testing.T) {
 	/* Set up */
 	db := useTestDb()
 	defer db.Close()
-	insertActivistForInterestTest(t, db, testfixtures.NewActivistBuilder().
+	model.MustInsertActivist(t, db, model.NewActivistBuilder().
 		WithName("Bob").
 		WithEmail("match@example.org").
 		Build())
-	insertActivistForInterestTest(t, db, testfixtures.NewActivistBuilder().
+	model.MustInsertActivist(t, db, model.NewActivistBuilder().
 		WithName("Carl").
 		WithEmail("match@example.org").
 		Build())
@@ -166,12 +157,12 @@ func TestProcessFormInterestForMatchingChapterIdAndName(t *testing.T) {
 	db := useTestDb()
 	defer db.Close()
 
-	insertActivistForInterestTest(t, db, testfixtures.NewActivistBuilder().
+	model.MustInsertActivist(t, db, model.NewActivistBuilder().
 		WithName("Sam").
 		WithEmail("foo@example.org").
 		WithChapterID(10).
 		Build())
-	insertActivistForInterestTest(t, db, testfixtures.NewActivistBuilder().
+	model.MustInsertActivist(t, db, model.NewActivistBuilder().
 		WithName("Sam").
 		WithEmail("bar@example.org").
 		WithChapterID(20).
@@ -195,12 +186,12 @@ func TestProcessFormInterestForMatchingChapterIdAndEmail(t *testing.T) {
 	db := useTestDb()
 	defer db.Close()
 
-	insertActivistForInterestTest(t, db, testfixtures.NewActivistBuilder().
+	model.MustInsertActivist(t, db, model.NewActivistBuilder().
 		WithName("Alice").
 		WithEmail("match@example.org").
 		WithChapterID(10).
 		Build())
-	insertActivistForInterestTest(t, db, testfixtures.NewActivistBuilder().
+	model.MustInsertActivist(t, db, model.NewActivistBuilder().
 		WithName("Bob").
 		WithEmail("match@example.org").
 		WithChapterID(20).
@@ -224,7 +215,7 @@ func TestProcessFormInterestForNonMatchingChapter(t *testing.T) {
 	db := useTestDb()
 	defer db.Close()
 
-	insertActivistForInterestTest(t, db, testfixtures.NewActivistBuilder().
+	model.MustInsertActivist(t, db, model.NewActivistBuilder().
 		WithName("Alice").
 		WithEmail("match@example.org").
 		WithChapterID(10).Build())

--- a/server/src/main.go
+++ b/server/src/main.go
@@ -817,10 +817,12 @@ func (c MainController) SwitchActiveChapterHandler(w http.ResponseWriter, r *htt
 
 func (c MainController) DevTestingProcessInterestForms(w http.ResponseWriter, r *http.Request) {
 	form_processor.ProcessInterestForms(c.db)
+	w.WriteHeader(http.StatusOK)
 }
 
 func (c MainController) DevTestingProcessApplicationForms(w http.ResponseWriter, r *http.Request) {
 	form_processor.ProcessApplicationForms(c.db)
+	w.WriteHeader(http.StatusOK)
 }
 
 func (c MainController) DevTestingProcessIntlAppForms(w http.ResponseWriter, r *http.Request) {

--- a/server/src/model/activist.go
+++ b/server/src/model/activist.go
@@ -1509,27 +1509,27 @@ func stringMergeSqlNullTime(original mysql.NullTime, target mysql.NullTime) mysq
 }
 
 // Merges address and coords. In ADB, coords are computed from address, so they are merged atomically with the adddress here.
-func mergeAddress(original ActivistAddress, originalCoords Coords, originalUpdated time.Time, target ActivistAddress, targetCoords Coords, targetUpdated time.Time) (ActivistAddress, Coords, time.Time) {
-	// Determine which address is newer
-	newer, newerCoords, newerUpdated := target, targetCoords, targetUpdated
-	older, olderCoords, olderUpdated := original, originalCoords, originalUpdated
+func mergeAddress(originalAddr ActivistAddress, originalCoords Coords, originalUpdated time.Time, target ActivistAddress, targetCoords Coords, targetUpdated time.Time) (ActivistAddress, Coords, time.Time) {
+	// Determine which address is newerAddr
+	newerAddr, newerCoords, newerUpdated := target, targetCoords, targetUpdated
+	olderAddr, olderCoords, olderUpdated := originalAddr, originalCoords, originalUpdated
 	if originalUpdated.After(targetUpdated) {
-		newer, newerCoords, newerUpdated = original, originalCoords, originalUpdated
-		older, olderCoords, olderUpdated = target, targetCoords, targetUpdated
+		newerAddr, newerCoords, newerUpdated = originalAddr, originalCoords, originalUpdated
+		olderAddr, olderCoords, olderUpdated = target, targetCoords, targetUpdated
 	}
 	// Return older if newer is empty
-	if newer.StreetAddress == "" && newer.City == "" && newer.State == "" &&
-		(older.StreetAddress != "" || older.City != "" || older.State != "") {
-		return older, olderCoords, olderUpdated
+	if newerAddr.StreetAddress == "" && newerAddr.City == "" && newerAddr.State == "" &&
+		(olderAddr.StreetAddress != "" || olderAddr.City != "" || olderAddr.State != "") {
+		return olderAddr, olderCoords, olderUpdated
 	}
-	addr := newer
+	addr := newerAddr
 	// If newer is missing city, use from older if both have the same state
-	if addr.City == "" && older.City != "" && addr.State == older.State {
-		addr.City = older.City
+	if addr.City == "" && olderAddr.City != "" && addr.State == olderAddr.State {
+		addr.City = olderAddr.City
 	}
 	// If newer is missing street address, use from older if both have the same city
-	if addr.StreetAddress == "" && older.StreetAddress != "" && addr.City == older.City && addr.State == older.State {
-		addr.StreetAddress = older.StreetAddress
+	if addr.StreetAddress == "" && olderAddr.StreetAddress != "" && addr.City == olderAddr.City && addr.State == olderAddr.State {
+		addr.StreetAddress = olderAddr.StreetAddress
 	}
 	return addr, newerCoords, newerUpdated
 }

--- a/server/src/model/activist.go
+++ b/server/src/model/activist.go
@@ -251,8 +251,8 @@ SET ` +
 	// data value instead of the old and it will appear as if the values of the data fields did not change, e.g.
 	// `email` would always be equal to `:email`.
 	`
-  email_updated = IF(email <> :email, NOW(), email_updated),'
-  phone_updated = IF(phone <> :phone, NOW(), phone_updated),'
+  email_updated = IF(email <> :email, NOW(), email_updated),
+  phone_updated = IF(phone <> :phone, NOW(), phone_updated),
   address_updated = IF(street_address <> :street_address OR city <> :city OR state <> :state, NOW(), address_updated),
   location_updated = IF(street_address <> :street_address OR city <> :city OR state <> :state OR NOT location <=> :location, NOW(), location_updated),
 ` + ActivistDataFieldAssignments + `
@@ -879,7 +879,7 @@ func GetActivistsExtra(db *sqlx.DB, options GetActivistOptions) ([]ActivistExtra
 			whereClause = append(whereClause, "a.chapter_id = "+strconv.Itoa(options.ChapterID))
 		}
 
-		if options.Hidden == true {
+		if options.Hidden {
 			whereClause = append(whereClause, "a.hidden = true")
 		} else {
 			whereClause = append(whereClause, "a.hidden = false")
@@ -1180,10 +1180,11 @@ func UpdateActivistData(db *sqlx.DB, activist ActivistExtra, userEmail string) (
 		err := mailing_list_signup.Enqueue(signup)
 		if err != nil {
 			// Don't return this error because we still want to successfully update the activist in the database.
-			fmt.Println("ERROR updating activist on mailing list:", err.Error())
+			log.Println("ERROR updating activist on mailing list:", err.Error())
+		} else {
+			log.Printf("Pushed updated activist record to sign-up service: name: %v, email: %v, chapter: %v",
+				activist.Name, activist.Email, activist.ChapterID)
 		}
-		log.Printf("Pushed updated activist record to sign-up service: name: %v, email: %v, chapter: %v",
-			activist.Name, activist.Email, activist.ChapterID)
 	}
 	geoInfoChanged := activist.City != origActivist.City ||
 		activist.State != origActivist.State ||

--- a/server/src/model/activist_test.go
+++ b/server/src/model/activist_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -352,67 +353,236 @@ func TestHideActivist(t *testing.T) {
 	assertStringsSliceUnorderedEquals(t, attendanceNames, []string{a1.Name, a2.Name})
 }
 
+func mustParseTime(t *testing.T, s string) time.Time {
+	time, err := time.Parse("2006-01-02", s)
+	require.NoError(t, err)
+	return time
+}
+
 func TestMergeActivist(t *testing.T) {
-	db := newTestDB()
-	defer db.Close()
+	t.Run("ContactInfo", func(t *testing.T) {
+		t.Run("MergesNewerValues", func(t *testing.T) {
+			db := newTestDB()
+			defer db.Close()
 
-	// Test that deleting activists works
-	a1, err := GetOrCreateActivist(db, "Test Activist", 1)
-	require.NoError(t, err)
+			a1 := NewActivistBuilder().
+				WithEmail("berkeley@example.org").
+				WithPhone("510-555-5555").
+				Build()
+			a1.EmailUpdated = mustParseTime(t, "2025-01-02")
+			a1.PhoneUpdated = mustParseTime(t, "2025-01-02")
+			MustInsertActivistWithTimestamps(t, db, a1)
 
-	a2, err := GetOrCreateActivist(db, "Another Test Activist", 1)
-	require.NoError(t, err)
+			a2 := NewActivistBuilder().
+				WithEmail("old@example.org").
+				WithPhone("510-555-0000").
+				Build()
+			a2.EmailUpdated = mustParseTime(t, "2025-01-01")
+			a2.PhoneUpdated = mustParseTime(t, "2025-01-01")
+			MustInsertActivistWithTimestamps(t, db, a2)
 
-	a3, err := GetOrCreateActivist(db, "A Third Test Activist", 1)
-	require.NoError(t, err)
+			require.NoError(t, MergeActivist(db, a1.ID, a2.ID))
+			a2 = MustGetActivist(t, db, a2.ID)
+			assert.Equal(t, "berkeley@example.org", a2.Email)
+			assert.Equal(t, mustParseTime(t, "2025-01-02"), a2.EmailUpdated)
+			assert.Equal(t, "510-555-5555", a2.Phone)
+			assert.Equal(t, mustParseTime(t, "2025-01-02"), a2.PhoneUpdated)
+		})
 
-	d1, err := time.Parse("2006-01-02", "2017-04-15")
-	require.NoError(t, err)
-	d2, err := time.Parse("2006-01-02", "2017-04-16")
-	require.NoError(t, err)
-	d3, err := time.Parse("2006-01-02", "2017-04-17")
-	require.NoError(t, err)
+		t.Run("DoesNotMergeNewerButEmptyValues", func(t *testing.T) {
+			db := newTestDB()
+			defer db.Close()
 
-	insertEvents := []Event{{
-		ID:             1,
-		EventName:      "event one",
-		EventDate:      d1,
-		EventType:      "Working Group",
-		AddedAttendees: []Activist{a1, a3},
-	}, {
-		ID:             2,
-		EventName:      "event two",
-		EventDate:      d2,
-		EventType:      "Working Group",
-		AddedAttendees: []Activist{a1, a2, a3},
-	}, {
-		ID:             3,
-		EventName:      "event three",
-		EventDate:      d3,
-		EventType:      "Working Group",
-		AddedAttendees: []Activist{a2, a3},
-	}}
-	mustInsertAllEvents(t, db, insertEvents)
+			a1 := NewActivistBuilder().
+				WithEmail("").
+				WithPhone("").
+				Build()
+			a1.EmailUpdated = mustParseTime(t, "2025-01-02") // Newer
+			a1.PhoneUpdated = mustParseTime(t, "2025-01-02") // Newer
+			MustInsertActivistWithTimestamps(t, db, a1)
 
-	require.NoError(t, MergeActivist(db, a1.ID, a2.ID))
+			a2 := NewActivistBuilder().
+				WithEmail("old@example.org").
+				WithPhone("510-555-0000").
+				Build()
+			a2.EmailUpdated = mustParseTime(t, "2025-01-01")
+			a2.PhoneUpdated = mustParseTime(t, "2025-01-01")
+			MustInsertActivistWithTimestamps(t, db, a2)
 
-	e1, err := GetEvent(db, GetEventOptions{EventID: 1})
-	require.NoError(t, err)
-	require.Equal(t, len(e1.Attendees), 2)
-	require.Equal(t, e1.Attendees[0], a2.Name)
-	require.Equal(t, e1.Attendees[1], a3.Name)
+			require.NoError(t, MergeActivist(db, a1.ID, a2.ID))
+			a2 = MustGetActivist(t, db, a2.ID)
+			assert.Equal(t, "old@example.org", a2.Email)
+			assert.Equal(t, mustParseTime(t, "2025-01-01"), a2.EmailUpdated)
+			assert.Equal(t, "510-555-0000", a2.Phone)
+			assert.Equal(t, mustParseTime(t, "2025-01-01"), a2.PhoneUpdated)
+		})
 
-	e2, err := GetEvent(db, GetEventOptions{EventID: 2})
-	require.NoError(t, err)
-	require.Equal(t, len(e2.Attendees), 2)
-	require.Equal(t, e2.Attendees[0], a2.Name)
-	require.Equal(t, e2.Attendees[1], a3.Name)
+		t.Run("DoesNotMergeOlderValues", func(t *testing.T) {
+			db := newTestDB()
+			defer db.Close()
 
-	e3, err := GetEvent(db, GetEventOptions{EventID: 3})
-	require.NoError(t, err)
-	require.Equal(t, len(e3.Attendees), 2)
-	require.Equal(t, e3.Attendees[0], a2.Name)
-	require.Equal(t, e3.Attendees[1], a3.Name)
+			a1 := NewActivistBuilder().
+				WithEmail("old@example.org").
+				WithPhone("510-555-0000").
+				Build()
+			a1.EmailUpdated = mustParseTime(t, "2025-01-01")
+			a1.PhoneUpdated = mustParseTime(t, "2025-01-01")
+			MustInsertActivistWithTimestamps(t, db, a1)
+
+			a2 := NewActivistBuilder().
+				WithEmail("berkeley@example.org").
+				WithPhone("510-555-5555").
+				Build()
+			a2.EmailUpdated = mustParseTime(t, "2025-01-02")
+			a2.PhoneUpdated = mustParseTime(t, "2025-01-02")
+			MustInsertActivistWithTimestamps(t, db, a2)
+
+			require.NoError(t, MergeActivist(db, a1.ID, a2.ID))
+			a2 = MustGetActivist(t, db, a2.ID)
+			assert.Equal(t, "berkeley@example.org", a2.Email)
+			assert.Equal(t, mustParseTime(t, "2025-01-02"), a2.EmailUpdated)
+			assert.Equal(t, "510-555-5555", a2.Phone)
+			assert.Equal(t, mustParseTime(t, "2025-01-02"), a2.PhoneUpdated)
+		})
+	})
+
+	t.Run("Address", func(t *testing.T) {
+		t.Run("MergesNewerValues", func(t *testing.T) {
+			db := newTestDB()
+			defer db.Close()
+
+			a1 := NewActivistBuilder().
+				WithAddress("100 Berkeley Way", "Berkeley", "CA").
+				WithCoords(1, 2).
+				Build()
+			a1.AddressUpdated = mustParseTime(t, "2025-01-02")
+			MustInsertActivistWithTimestamps(t, db, a1)
+
+			a2 := NewActivistBuilder().
+				WithAddress("200 Berkeley Way", "Berkeley", "CA").
+				WithCoords(3, 4).
+				Build()
+			a2.AddressUpdated = mustParseTime(t, "2025-01-01")
+			MustInsertActivistWithTimestamps(t, db, a2)
+
+			require.NoError(t, MergeActivist(db, a1.ID, a2.ID))
+			a2 = MustGetActivist(t, db, a2.ID)
+			assert.Equal(t, mustParseTime(t, "2025-01-02"), a2.AddressUpdated)
+			assert.Equal(t, mustParseTime(t, "2025-01-02"), a2.LocationUpdated)
+			assert.Equal(t, "100 Berkeley Way", a2.StreetAddress)
+			assert.Equal(t, Coords{1, 2}, a2.Coords)
+		})
+
+		t.Run("DoesNotMergeNewerButEmptyValues", func(t *testing.T) {
+			db := newTestDB()
+			defer db.Close()
+
+			a1 := NewActivistBuilder().
+				WithAddress("", "", "").
+				WithCoords(0, 0).
+				Build()
+			a1.AddressUpdated = mustParseTime(t, "2025-01-02") // Newer
+			MustInsertActivistWithTimestamps(t, db, a1)
+
+			a2 := NewActivistBuilder().
+				WithAddress("200 Berkeley Way", "Berkeley", "CA").
+				WithCoords(3, 4).
+				Build()
+			a2.AddressUpdated = mustParseTime(t, "2025-01-01")
+			MustInsertActivistWithTimestamps(t, db, a2)
+
+			require.NoError(t, MergeActivist(db, a1.ID, a2.ID))
+			a2 = MustGetActivist(t, db, a2.ID)
+			assert.Equal(t, mustParseTime(t, "2025-01-01"), a2.AddressUpdated)
+			assert.Equal(t, "200 Berkeley Way", a2.StreetAddress)
+			assert.Equal(t, Coords{3, 4}, a2.Coords)
+		})
+
+		t.Run("DoesNotMergeOlderValues", func(t *testing.T) {
+			db := newTestDB()
+			defer db.Close()
+
+			a1 := NewActivistBuilder().
+				WithAddress("100 Berkeley Way", "Berkeley", "CA").
+				WithCoords(1, 2).
+				Build()
+			a1.AddressUpdated = mustParseTime(t, "2025-01-01")
+			MustInsertActivistWithTimestamps(t, db, a1)
+
+			a2 := NewActivistBuilder().
+				WithAddress("200 Berkeley Way", "Berkeley", "CA").
+				WithCoords(3, 4).
+				Build()
+			a2.AddressUpdated = mustParseTime(t, "2025-01-02")
+			MustInsertActivistWithTimestamps(t, db, a2)
+
+			require.NoError(t, MergeActivist(db, a1.ID, a2.ID))
+			a2 = MustGetActivist(t, db, a2.ID)
+			assert.Equal(t, mustParseTime(t, "2025-01-02"), a2.AddressUpdated)
+			assert.Equal(t, "200 Berkeley Way", a2.StreetAddress)
+			assert.Equal(t, Coords{3, 4}, a2.Coords)
+		})
+	})
+
+	t.Run("MergesEvents", func(t *testing.T) {
+		db := newTestDB()
+		defer db.Close()
+
+		// Test that deleting activists works
+		a1, err := GetOrCreateActivist(db, "Test Activist", 1)
+		require.NoError(t, err)
+
+		a2, err := GetOrCreateActivist(db, "Another Test Activist", 1)
+		require.NoError(t, err)
+
+		a3, err := GetOrCreateActivist(db, "A Third Test Activist", 1)
+		require.NoError(t, err)
+
+		d1 := mustParseTime(t, "2017-04-15")
+		d2 := mustParseTime(t, "2017-04-16")
+		d3 := mustParseTime(t, "2017-04-17")
+
+		insertEvents := []Event{{
+			ID:             1,
+			EventName:      "event one",
+			EventDate:      d1,
+			EventType:      "Working Group",
+			AddedAttendees: []Activist{a1, a3},
+		}, {
+			ID:             2,
+			EventName:      "event two",
+			EventDate:      d2,
+			EventType:      "Working Group",
+			AddedAttendees: []Activist{a1, a2, a3},
+		}, {
+			ID:             3,
+			EventName:      "event three",
+			EventDate:      d3,
+			EventType:      "Working Group",
+			AddedAttendees: []Activist{a2, a3},
+		}}
+		mustInsertAllEvents(t, db, insertEvents)
+
+		require.NoError(t, MergeActivist(db, a1.ID, a2.ID))
+
+		e1, err := GetEvent(db, GetEventOptions{EventID: 1})
+		require.NoError(t, err)
+		require.Equal(t, len(e1.Attendees), 2)
+		require.Equal(t, e1.Attendees[0], a2.Name)
+		require.Equal(t, e1.Attendees[1], a3.Name)
+
+		e2, err := GetEvent(db, GetEventOptions{EventID: 2})
+		require.NoError(t, err)
+		require.Equal(t, len(e2.Attendees), 2)
+		require.Equal(t, e2.Attendees[0], a2.Name)
+		require.Equal(t, e2.Attendees[1], a3.Name)
+
+		e3, err := GetEvent(db, GetEventOptions{EventID: 3})
+		require.NoError(t, err)
+		require.Equal(t, len(e3.Attendees), 2)
+		require.Equal(t, e3.Attendees[0], a2.Name)
+		require.Equal(t, e3.Attendees[1], a3.Name)
+	})
 }
 
 // Not Specfiying a starting name with ascending order

--- a/server/src/model/activist_test_utils.go
+++ b/server/src/model/activist_test_utils.go
@@ -1,19 +1,23 @@
-package testfixtures
+package model
 
-import "github.com/dxe/adb/model"
+import (
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+)
 
 type ActivistBuilder struct {
-	activist model.ActivistExtra
+	activist ActivistExtra
 }
 
 func NewActivistBuilder() *ActivistBuilder {
 	return &ActivistBuilder{
-		activist: model.ActivistExtra{
-			Activist: model.Activist{
+		activist: ActivistExtra{
+			Activist: Activist{
 				ID:        0,
 				Email:     "email1",
 				Name:      "name1",
-				ChapterID: model.SFBayChapterIdDevTest,
+				ChapterID: SFBayChapterIdDevTest,
 			},
 		},
 	}
@@ -34,6 +38,14 @@ func (b *ActivistBuilder) WithChapterID(chapterID int) *ActivistBuilder {
 	return b
 }
 
-func (b *ActivistBuilder) Build() *model.ActivistExtra {
+func (b *ActivistBuilder) Build() *ActivistExtra {
 	return &b.activist
+}
+
+func MustInsertActivist(t *testing.T, db *sqlx.DB, activist *ActivistExtra) {
+	id, err := CreateActivist(db, *activist)
+	if err != nil {
+		t.Fatalf("MustInsertActivist failed: %s", err)
+	}
+	activist.ID = id
 }

--- a/server/src/model/activist_test_utils.go
+++ b/server/src/model/activist_test_utils.go
@@ -1,31 +1,45 @@
 package model
 
 import (
+	"database/sql"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/jmoiron/sqlx"
 )
+
+func parseTimeOrPanic(s string) time.Time {
+	time, err := time.Parse("2006-01-02 15:04:05", s)
+	if err != nil {
+		panic(err)
+	}
+	return time
+}
 
 type ActivistBuilder struct {
 	activist ActivistExtra
 }
 
+var defaultModificationTime = parseTimeOrPanic("1970-01-01 00:00:01")
+
 func NewActivistBuilder() *ActivistBuilder {
 	return &ActivistBuilder{
 		activist: ActivistExtra{
 			Activist: Activist{
-				ID:        0,
-				Email:     "email1",
-				Name:      "name1",
-				ChapterID: SFBayChapterIdDevTest,
+				ID:           0,
+				Name:         "name" + fmt.Sprintf("%d", time.Now().UnixNano()),
+				ChapterID:    SFBayChapterIdDevTest,
+				EmailUpdated: defaultModificationTime,
+				PhoneUpdated: defaultModificationTime,
+
+				LocationUpdated: defaultModificationTime,
+			},
+			ActivistConnectionData: ActivistConnectionData{
+				AddressUpdated: defaultModificationTime,
 			},
 		},
 	}
-}
-
-func (b *ActivistBuilder) WithEmail(email string) *ActivistBuilder {
-	b.activist.Email = email
-	return b
 }
 
 func (b *ActivistBuilder) WithName(name string) *ActivistBuilder {
@@ -33,8 +47,36 @@ func (b *ActivistBuilder) WithName(name string) *ActivistBuilder {
 	return b
 }
 
+func (b *ActivistBuilder) WithEmail(email string) *ActivistBuilder {
+	b.activist.Email = email
+	return b
+}
+
+func (b *ActivistBuilder) WithPhone(phone string) *ActivistBuilder {
+	b.activist.Phone = phone
+	return b
+}
+
 func (b *ActivistBuilder) WithChapterID(chapterID int) *ActivistBuilder {
 	b.activist.ChapterID = chapterID
+	return b
+}
+
+func (b *ActivistBuilder) WithAddress(street string, city string, state string) *ActivistBuilder {
+	b.activist.StreetAddress = street
+	b.activist.City = city
+	b.activist.State = state
+	return b
+}
+
+func (b *ActivistBuilder) WithLocation(location sql.NullString) *ActivistBuilder {
+	b.activist.Location = location
+	return b
+}
+
+func (b *ActivistBuilder) WithCoords(lat float64, lng float64) *ActivistBuilder {
+	b.activist.Lat = lat
+	b.activist.Lng = lng
 	return b
 }
 
@@ -45,7 +87,23 @@ func (b *ActivistBuilder) Build() *ActivistExtra {
 func MustInsertActivist(t *testing.T, db *sqlx.DB, activist *ActivistExtra) {
 	id, err := CreateActivist(db, *activist)
 	if err != nil {
-		t.Fatalf("MustInsertActivist failed: %s", err)
+		t.Fatalf("MustInsertActivist failed: %v", err)
 	}
 	activist.ID = id
+}
+
+func MustInsertActivistWithTimestamps(t *testing.T, db *sqlx.DB, activist *ActivistExtra) {
+	id, err := CreateActivistWithTimestamps(db, *activist)
+	if err != nil {
+		t.Fatalf("MustInsertActivistWithTimestamps failed: %v", err)
+	}
+	activist.ID = id
+}
+
+func MustGetActivist(t *testing.T, db *sqlx.DB, id int) *ActivistExtra {
+	activist, err := GetActivistExtra(db, id)
+	if err != nil {
+		t.Fatalf("MustGetActivist failed: %v", err)
+	}
+	return activist
 }


### PR DESCRIPTION
* feat: add timestamp columns to activists
This allows smarter merging of activist records. This is especially
important because in the future we may decide to merge activist records
across chapters. We suspect there may be a lot of activists in multiple
chapters now that check-in forms systematically duplicate activists
across chapters when someone gives a zip code near one chapter (which is
presumed to be their home chapter) on a check-in form belonging to
another chapter (which needs the same activist info for attendance).

* chore: deduplicate update queries for activist update
One was missing dev_application_date and dev_application_type and the
other was missing lat, lng and coords_updated. Combining so all fields
will get updated in all cases.