### PR TITLE
fix: add activists only to mailing list near zip

### DIFF
--- a/server/src/model/activist.go
+++ b/server/src/model/activist.go
@@ -1180,14 +1180,17 @@ func UpdateActivistData(db *sqlx.DB, activist ActivistExtra, userEmail string) (
 		activist.ActivistLevel != origActivist.ActivistLevel
 	if mailingListInfoChanged && activist.Email != "" {
 		signup := mailing_list_signup.Signup{
-			Source:          "adb",
-			Name:            activist.Name,
-			Email:           activist.Email,
-			Phone:           activist.Phone,
-			City:            activist.City,
-			State:           activist.State,
-			Zip:             activist.Location.String,
-			TargetChapterId: activist.ChapterID,
+			Source: "adb",
+			Name:   activist.Name,
+			Email:  activist.Email,
+			Phone:  activist.Phone,
+			City:   activist.City,
+			State:  activist.State,
+			// Zip will be used to find a chapter mailing list (often this chapter's mailing list).
+			// Activist may be added to ADB chapter near this zip, if different from this chapter.
+			Zip: activist.Location.String,
+			// Let signup service know this chapter's ID so it doesn't try to sync back here causing an infinite loop.
+			SourceChapterId: activist.ChapterID,
 			ActivistLevel:   activist.ActivistLevel,
 		}
 		err := mailing_list_signup.Enqueue(signup)


### PR DESCRIPTION
When an activist is updated in ADB, subscribe them to the mailing list near their home chapter (chapter near their zip code) rather than to this chapter's mailing list. Also add them to the home chapter ADB if different.

This is done by telling the sign-up service that the current chapter is the "source chapter", freeing up "target chapter" to be selected automatically based on zip code.