### PR TITLE
fix: Do not fail when rows affected > 1 in application processors

### DIFF
--- a/server/src/form_processor/application_form_processor.go
+++ b/server/src/form_processor/application_form_processor.go
@@ -288,7 +288,7 @@ func tryUpdateActivistWithApplicationFormBasedOnName(db *sqlx.DB, response formR
 		return false, fmt.Errorf("failed to get processApplicationOnNameQuery affected rows; %s",
 			getRowsAffectedErr)
 	}
-	return updateCount == 1, nil
+	return updateCount > 0, nil
 }
 
 func updateActivistWithApplicationFormBasedOnEmail(db *sqlx.DB, id int) error {
@@ -302,7 +302,7 @@ func updateActivistWithApplicationFormBasedOnEmail(db *sqlx.DB, id int) error {
 		return fmt.Errorf("failed to get processApplicationOnEmailQuery affected rows; %s",
 			getRowsAffectedErr)
 	}
-	if count != 1 {
+	if count == 0 {
 		return fmt.Errorf("no rows updated on processApplicationOnEmailQuery")
 	}
 
@@ -327,7 +327,7 @@ func insertActivistFromApplicationForm(db *sqlx.DB, id int) error {
 		return fmt.Errorf("failed to get processApplicationByInsertQuery affected rows; %s",
 			getRowsAffectedErr)
 	}
-	if insertCount != 1 {
+	if insertCount == 0 {
 		return fmt.Errorf("no rows updated on processApplicationByInsertQuery")
 	}
 
@@ -341,7 +341,7 @@ func insertActivistFromApplicationForm(db *sqlx.DB, id int) error {
 		return fmt.Errorf("failed to get markApplicationProcessedQuery affected rows; %s",
 			getRowsAffectedErr)
 	}
-	if markCount != 1 {
+	if markCount == 0 {
 		log.Error().Msg("application form was processed but not marked as such")
 	}
 

--- a/server/src/form_processor/interest_form_processor.go
+++ b/server/src/form_processor/interest_form_processor.go
@@ -270,7 +270,7 @@ func tryUpdateActivistWithInterestFormBasedOnName(db *sqlx.DB, response formResp
 		return false, fmt.Errorf("failed to get processInterestOnNameQuery affected rows; %s",
 			getRowsAffectedErr)
 	}
-	return updateCount == 1, nil
+	return updateCount > 0, nil
 }
 
 func updateActivistWithInterestFormBasedOnEmail(db *sqlx.DB, id int) error {
@@ -284,7 +284,7 @@ func updateActivistWithInterestFormBasedOnEmail(db *sqlx.DB, id int) error {
 		return fmt.Errorf("failed to get processInterestOnEmailQuery affected rows; %s",
 			getRowsAffectedErr)
 	}
-	if count != 1 {
+	if count == 0 {
 		return fmt.Errorf("no rows updated on processInterestOnEmailQuery")
 	}
 
@@ -309,7 +309,7 @@ func insertActivistFromInterestForm(db *sqlx.DB, id int) error {
 		return fmt.Errorf("failed to get processInterestByInsertQuery affected rows; %s",
 			getRowsAffectedErr)
 	}
-	if insertCount != 1 {
+	if insertCount == 0 {
 		return fmt.Errorf("no rows updated on processInterestByInsertQuery")
 	}
 
@@ -323,7 +323,7 @@ func insertActivistFromInterestForm(db *sqlx.DB, id int) error {
 		return fmt.Errorf("failed to get markInterestProcessedQuery affected rows; %s",
 			getRowsAffectedErr)
 	}
-	if markCount != 1 {
+	if markCount == 0 {
 		log.Error().Msg("interest form was processed but not marked as such")
 	}
 


### PR DESCRIPTION
I'm seeing alerts in prod due to processing errors, but the database shows they are still getting marked as processed.

Maybe unit tests don't fail due to a difference in Maria DB used in prod vs MySql or lack of coverage, but anyway hopefully this fixes it.