### PR TITLE
Auth and logging fixes

### DIFF
--- a/server/scripts/create_db_wrapper/create_db.go
+++ b/server/scripts/create_db_wrapper/create_db.go
@@ -84,7 +84,7 @@ INSERT INTO event_attendance (activist_id, event_id) VALUES
   (1, 1), (1, 2), (2, 2), (3,3), (4,6), (5,5), (5,1), (5,6);
 
 INSERT INTO adb_users (id, email, name, admin, disabled, chapter_id) VALUES
-  (1, 'nosefrog@gmail.com', 'Samer Masterson', 1, 0, 1),
+  (1, '`+model.DevTestUserEmail+`', 'Test User', 1, 0, `+model.SFBayChapterIdDevTestStr+`),
   (2, 'cwbailey20042@gmail.com', 'Cameron Bailey', 1, 0, 1),
   (3, 'jakehobbs@gmail.com', 'Jake Hobbs', 1, 0, 1),
   (4, 'samer@directactioneverywhere.com', 'The Real Samer', 1, 0, 0),
@@ -95,7 +95,7 @@ INSERT INTO users_roles (user_id, role)
 SELECT id, 'admin' FROM adb_users WHERE id IN(1, 2, 3, 4, 5, 6);
 
 INSERT INTO fb_pages (id, name, flag, fb_url, twitter_url, insta_url, email, region, lat, lng, token, organizers) VALUES
-(1, 'SF Bay Area', 'z', 'facebook.com/a', 'twitter.com/a', 'instagram.com/a', 'a@dxe.io', 'North America', '1.000', '2.000', 'xyz', "[]"),
+(1, '`+model.SFBayChapterName+`', 'z', 'facebook.com/a', 'twitter.com/a', 'instagram.com/a', 'a@dxe.io', 'North America', '1.000', '2.000', 'xyz', "[]"),
 (2, 'Chapter B', 'z', 'facebook.com/b', 'twitter.com/b', 'instagram.com/b', 'b@dxe.io', 'North America', '3.000', '2.000', '', "[]"),
 (3, 'Chapter C', 'z', 'facebook.com/c', 'twitter.com/c', 'instagram.com/c', 'c@dxe.io', 'North America', '7.000', '1.000', '', "[]");
 

--- a/server/src/main.go
+++ b/server/src/main.go
@@ -155,7 +155,9 @@ func setAuthSession(w http.ResponseWriter, r *http.Request, adbUser model.ADBUse
 
 	authSession, err := sessionStore.Get(r, "auth-session")
 	if err != nil {
-		return err
+		// This err represents an issue with decoding an existing session.
+		// sessionStore.Get returns a new session in this case, so no need to return.
+		log.Printf("Warning: creating a new session because the existing session could not be decoded: %v", err)
 	}
 	authSession.Options = &sessions.Options{
 		Path: "/",

--- a/server/src/model/activist.go
+++ b/server/src/model/activist.go
@@ -1235,7 +1235,7 @@ func UpdateActivistData(db *sqlx.DB, activist ActivistExtra, userEmail string) (
 	})
 
 	if err != nil {
-		fmt.Println("Error logging activist update: " + err.Error())
+		log.Println("Error logging activist update: " + err.Error())
 	}
 
 	return activist.ID, nil

--- a/server/src/model/activist_test.go
+++ b/server/src/model/activist_test.go
@@ -23,17 +23,17 @@ func TestAutocompleteActivistsHandler(t *testing.T) {
 	db := newTestDB()
 	defer db.Close()
 
-	_, err := GetOrCreateActivist(db, "Activist One", 1)
+	_, err := GetOrCreateActivist(db, "Activist One", SFBayChapterIdDevTest)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = GetOrCreateActivist(db, "Activist Two", 1)
+	_, err = GetOrCreateActivist(db, "Activist Two", SFBayChapterIdDevTest)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	gotNames := GetAutocompleteNames(db, 1)
+	gotNames := GetAutocompleteNames(db, SFBayChapterIdDevTest)
 	wantNames := []string{"Activist One", "Activist Two"}
 
 	if len(gotNames) != len(wantNames) {
@@ -48,7 +48,7 @@ func TestGetActivistEventData(t *testing.T) {
 	db := newTestDB()
 	defer db.Close()
 
-	a1, err := GetOrCreateActivist(db, "Test Activist", 1)
+	a1, err := GetOrCreateActivist(db, "Test Activist", SFBayChapterIdDevTest)
 	require.NoError(t, err)
 
 	d1, err := time.Parse("2006-01-02", "2017-04-15")
@@ -100,7 +100,7 @@ func TestGetActivistEventData_noEvents(t *testing.T) {
 	db := newTestDB()
 	defer db.Close()
 
-	a1, err := GetOrCreateActivist(db, "Test Activist", 1)
+	a1, err := GetOrCreateActivist(db, "Test Activist", SFBayChapterIdDevTest)
 	require.NoError(t, err)
 
 	d, err := a1.GetActivistEventData(db)
@@ -131,13 +131,13 @@ func TestGetActivistsJSON_RestrictDates(t *testing.T) {
 	db := newTestDB()
 	defer db.Close()
 
-	a1, err := GetOrCreateActivist(db, "A", 1)
+	a1, err := GetOrCreateActivist(db, "A", SFBayChapterIdDevTest)
 	require.NoError(t, err)
 
-	a2, err := GetOrCreateActivist(db, "B", 1)
+	a2, err := GetOrCreateActivist(db, "B", SFBayChapterIdDevTest)
 	require.NoError(t, err)
 
-	a3, err := GetOrCreateActivist(db, "C", 1)
+	a3, err := GetOrCreateActivist(db, "C", SFBayChapterIdDevTest)
 	require.NoError(t, err)
 
 	d1, err := time.Parse("2006-01-02", "2017-04-15")
@@ -194,13 +194,13 @@ func TestGetActivistsJSON_OrderField(t *testing.T) {
 	db := newTestDB()
 	defer db.Close()
 
-	a1, err := GetOrCreateActivist(db, "A", 1)
+	a1, err := GetOrCreateActivist(db, "A", SFBayChapterIdDevTest)
 	require.NoError(t, err)
 
-	a2, err := GetOrCreateActivist(db, "B", 1)
+	a2, err := GetOrCreateActivist(db, "B", SFBayChapterIdDevTest)
 	require.NoError(t, err)
 
-	a3, err := GetOrCreateActivist(db, "C", 1)
+	a3, err := GetOrCreateActivist(db, "C", SFBayChapterIdDevTest)
 	require.NoError(t, err)
 
 	d1, err := time.Parse("2006-01-02", "2017-04-15")
@@ -250,7 +250,7 @@ func TestGetActivistsJSON_FirstAndLastEvent(t *testing.T) {
 	db := newTestDB()
 	defer db.Close()
 
-	a1, err := GetOrCreateActivist(db, "A", 1)
+	a1, err := GetOrCreateActivist(db, "A", SFBayChapterIdDevTest)
 	require.NoError(t, err)
 
 	d1, err := time.Parse("2006-01-02", "2017-04-15")
@@ -407,10 +407,10 @@ func TestHideActivist(t *testing.T) {
 	defer db.Close()
 
 	// Test that deleting activists works
-	a1, err := GetOrCreateActivist(db, "Test Activist", 1)
+	a1, err := GetOrCreateActivist(db, "Test Activist", SFBayChapterIdDevTest)
 	require.NoError(t, err)
 
-	a2, err := GetOrCreateActivist(db, "Another Test Activist", 1)
+	a2, err := GetOrCreateActivist(db, "Another Test Activist", SFBayChapterIdDevTest)
 	require.NoError(t, err)
 
 	d1, err := time.Parse("2006-01-02", "2017-01-15")
@@ -426,7 +426,7 @@ func TestHideActivist(t *testing.T) {
 	require.NoError(t, HideActivist(db, a1.ID))
 
 	// Hidden activists should not show up in the autocompleted names
-	names := GetAutocompleteNames(db, 1)
+	names := GetAutocompleteNames(db, SFBayChapterIdDevTest)
 	require.Equal(t, len(names), 1)
 	require.Equal(t, names[0], a2.Name)
 
@@ -669,13 +669,13 @@ func TestMergeActivist(t *testing.T) {
 		defer db.Close()
 
 		// Test that deleting activists works
-		a1, err := GetOrCreateActivist(db, "Test Activist", 1)
+		a1, err := GetOrCreateActivist(db, "Test Activist", SFBayChapterIdDevTest)
 		require.NoError(t, err)
 
-		a2, err := GetOrCreateActivist(db, "Another Test Activist", 1)
+		a2, err := GetOrCreateActivist(db, "Another Test Activist", SFBayChapterIdDevTest)
 		require.NoError(t, err)
 
-		a3, err := GetOrCreateActivist(db, "A Third Test Activist", 1)
+		a3, err := GetOrCreateActivist(db, "A Third Test Activist", SFBayChapterIdDevTest)
 		require.NoError(t, err)
 
 		d1 := mustParseTime(t, "2017-04-15")

--- a/server/src/model/activist_test.go
+++ b/server/src/model/activist_test.go
@@ -388,7 +388,7 @@ func TestUpdateActivist(t *testing.T) {
 	activist.Location = sql.NullString{String: "90001", Valid: true}
 	activist.Coords = Coords{1, 2}
 
-	UpdateActivistData(db, *activist, DevTestUser.Email)
+	UpdateActivistData(db, *activist, DevTestUserEmail)
 
 	updatedActivist, err := GetActivistExtra(db, id)
 	require.NoError(t, err)

--- a/server/src/model/adb_auth.go
+++ b/server/src/model/adb_auth.go
@@ -2,8 +2,8 @@ package model
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
+	"log"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
@@ -133,7 +133,7 @@ FROM adb_users
 		}
 	}
 
-	fmt.Println("[User access]", adbUser.Name, "-", adbUser.Email)
+	log.Println("[User access]", adbUser.Name, "-", adbUser.Email)
 
 	return *adbUser, nil
 }

--- a/server/src/model/adb_auth.go
+++ b/server/src/model/adb_auth.go
@@ -62,17 +62,6 @@ type GetUsersRolesOptions struct {
 	Roles []string
 }
 
-var DevTestUser = ADBUser{
-	ID:          1,
-	Email:       "test@test.com",
-	Name:        "Test User",
-	Admin:       true,
-	Disabled:    false,
-	Roles:       []UserRole{{UserID: 1, Role: "admin"}},
-	ChapterID:   SFBayChapterIdDevTest,
-	ChapterName: SFBayChapterName,
-}
-
 type UserRole struct {
 	UserID int    `db:"user_id"`
 	Role   string `db:"role"`
@@ -82,6 +71,9 @@ type UserRoleJSON struct {
 	UserID int    `json:"user_id"`
 	Role   string `json:"role"`
 }
+
+const DevTestUserId = 1
+const DevTestUserEmail = "test@example.org"
 
 /** Functions and Methods */
 

--- a/server/src/model/adb_auth.go
+++ b/server/src/model/adb_auth.go
@@ -69,8 +69,8 @@ var DevTestUser = ADBUser{
 	Admin:       true,
 	Disabled:    false,
 	Roles:       []UserRole{{UserID: 1, Role: "admin"}},
-	ChapterID:   1,
-	ChapterName: "SF Bay Area",
+	ChapterID:   SFBayChapterIdDevTest,
+	ChapterName: SFBayChapterName,
 }
 
 type UserRole struct {
@@ -124,7 +124,7 @@ FROM adb_users
 	usersRoles, err := getUsersRoles(db, usersRolesOptions)
 
 	// We don't want non-SF Bay users to have access to any of the other roles, so just replace it.
-	if adbUser.ChapterName != "SF Bay Area" {
+	if adbUser.ChapterName != SFBayChapterName {
 		usersRoles = []UserRole{{
 			UserID: adbUser.ID,
 			Role:   "non-sfbay",

--- a/server/src/model/chapters.go
+++ b/server/src/model/chapters.go
@@ -85,6 +85,7 @@ type Organizer struct {
 
 type Organizers []*Organizer
 
+const SFBayChapterName = "SF Bay Area"
 const SFBayChapterId = 47
 const SFBayChapterIdStr = "47"
 const SFBayChapterIdDevTest = 1

--- a/server/src/model/event_test.go
+++ b/server/src/model/event_test.go
@@ -86,7 +86,7 @@ func TestGetEvents_orderBy(t *testing.T) {
 	db := newTestDB()
 	defer db.Close()
 
-	a1, err := GetOrCreateActivist(db, "Hello", 1)
+	a1, err := GetOrCreateActivist(db, "Hello", SFBayChapterIdDevTest)
 	require.NoError(t, err)
 
 	d1, err := time.Parse("2006-01-02", "2017-01-15")
@@ -136,9 +136,9 @@ func TestInsertUpdateEvent(t *testing.T) {
 	db := newTestDB()
 	defer db.Close()
 
-	a1, err := GetOrCreateActivist(db, "Hello", 1)
+	a1, err := GetOrCreateActivist(db, "Hello", SFBayChapterIdDevTest)
 	require.NoError(t, err)
-	a2, err := GetOrCreateActivist(db, "Hi", 1)
+	a2, err := GetOrCreateActivist(db, "Hi", SFBayChapterIdDevTest)
 	require.NoError(t, err)
 
 	event := Event{
@@ -187,7 +187,7 @@ func TestInsertUpdateEvent_noDuplicateAttendees(t *testing.T) {
 	db := newTestDB()
 	defer db.Close()
 
-	a1, err := GetOrCreateActivist(db, "Hello", 1)
+	a1, err := GetOrCreateActivist(db, "Hello", SFBayChapterIdDevTest)
 	require.NoError(t, err)
 
 	event := Event{
@@ -213,9 +213,9 @@ func TestDeleteEvents(t *testing.T) {
 	defer db.Close()
 
 	// Set up two events
-	a1, err := GetOrCreateActivist(db, "Hello", 1)
+	a1, err := GetOrCreateActivist(db, "Hello", SFBayChapterIdDevTest)
 	require.NoError(t, err)
-	a2, err := GetOrCreateActivist(db, "Hi", 1)
+	a2, err := GetOrCreateActivist(db, "Hi", SFBayChapterIdDevTest)
 	require.NoError(t, err)
 
 	d1, err := time.Parse("2006-01-02", "2017-01-15")

--- a/server/src/model/forms.go
+++ b/server/src/model/forms.go
@@ -90,7 +90,7 @@ func SubmitApplicationForm(db *sqlx.DB, formData ApplicationFormData) error {
 	err = mailing_list_signup.Enqueue(signup)
 	if err != nil {
 		// Don't fail the HTTP request since at least the user's response was added to the database.
-		fmt.Println("ERROR adding application form submission to mailing list:", err.Error())
+		log.Printf("ERROR adding application form submission to mailing list: %v", err)
 	}
 	log.Printf("Enqueued email for sign-up: %v", formData.Email)
 
@@ -212,7 +212,7 @@ func SubmitDiscordForm(db *sqlx.DB, formData DiscordFormData) error {
 	err = mailing_list_signup.Enqueue(signup)
 	if err != nil {
 		// Don't return this error because we still want to successfully update the database.
-		fmt.Println("ERROR adding discord form submission to mailing list:", err.Error())
+		log.Printf("ERROR adding discord form submission to mailing list: %v", err)
 	}
 	log.Printf("Enqueued email for sign-up: %v", formData.Email)
 

--- a/server/src/model/geo_helpers.go
+++ b/server/src/model/geo_helpers.go
@@ -2,7 +2,7 @@ package model
 
 import (
 	"encoding/json"
-	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 
@@ -29,21 +29,21 @@ type GeocodeResponse struct {
 
 func geoCodeAddress(streetAddress string, city string, state string) *Location {
 	if config.GooglePlacesBackendAPIKey == "" {
-		fmt.Println("GooglePlacesBackendAPIKey not configured.")
+		log.Println("GooglePlacesBackendAPIKey not configured.")
 		return nil
 	}
 	full_address := url.QueryEscape(streetAddress + " " + city + " " + state)
 	request := "https://maps.googleapis.com/maps/api/geocode/json?address=" + full_address + "&key=" + config.GooglePlacesBackendAPIKey
 	resp, err := http.Get(request)
 	if err != nil {
-		fmt.Println("Error geocoding activist location", err)
+		log.Println("Error geocoding activist location", err)
 		return nil
 	}
 	defer resp.Body.Close()
 	var geocode_response GeocodeResponse
 	json.NewDecoder(resp.Body).Decode(&geocode_response)
 	if len(geocode_response.Results) == 0 {
-		fmt.Printf("No geocoding results found for address %v. Not updating Lat and Lng\n", full_address)
+		log.Printf("No geocoding results found for address %v. Not updating Lat and Lng\n", full_address)
 		return nil
 	} else {
 		return &Location{Lat: geocode_response.Results[0].Geometry.Location.Lat, Lng: geocode_response.Results[0].Geometry.Location.Lng}

--- a/server/src/model/working_groups_test.go
+++ b/server/src/model/working_groups_test.go
@@ -199,7 +199,7 @@ func validateReturnedWorkingGroup(t *testing.T, inserted WorkingGroup, returned 
 func insertActivists(t *testing.T, db *sqlx.DB, names []string) []WorkingGroupMember {
 	members := make([]WorkingGroupMember, len(names))
 	for idx, a := range names {
-		activist, err := GetOrCreateActivist(db, a, 1)
+		activist, err := GetOrCreateActivist(db, a, SFBayChapterIdDevTest)
 		require.NoError(t, err)
 		members[idx] = WorkingGroupMember{
 			ActivistName: activist.Name,


### PR DESCRIPTION
* refactor: use constants for SF Bay ids

* test: use real database and cookies for dev test user

This removes a noisy message about not getting the chapter ID from the
cookie when there was no cookie.

* chore: replace fmt.Print* with log.Print* statements