### PR TITLE
fix: avoid overlapping form processor runs

### DIFF
--- a/server/src/config/config.go
+++ b/server/src/config/config.go
@@ -82,11 +82,6 @@ var (
 		"@every 10s",
 		false,
 	)
-	FormProcessorSendLogByEmailCronExpression = mustGetenv(
-		"FORM_PROCESSOR_SEND_LOG_BY_EMAIL_CRON_EXPRESSION",
-		"@daily",
-		false,
-	)
 	FormProcessorLockFilePath = mustGetenv(
 		"FORM_PROCESSOR_LOCK_FILE_PATH",
 		"output/FORM_PROCESSOR_ROCESSOR_RUNNING",


### PR DESCRIPTION
The form processor was causing race conditions with itself, when two instances would go to insert the same activist. This was causing noisy alerts in AWS.