### PR TITLE
fix: do not forget dev-application-* fields on update

### DIFF
--- a/server/scripts/create_db_wrapper/create_db.go
+++ b/server/scripts/create_db_wrapper/create_db.go
@@ -27,7 +27,7 @@ func createCurrentDateString(day int) string {
 	currentYear := currentTime.Year()
 	currentMonth := currentTime.Month()
 
-	return fmt.Sprintf("%d-%d-%d", currentYear, currentMonth, day)
+	return fmt.Sprintf("%02d-%02d-%02d", currentYear, currentMonth, day)
 }
 
 func createEventsDevDB() string {
@@ -57,24 +57,31 @@ func createDevDB(name string) {
 	db := model.NewDB(config.DataSourceBase + "/" + name + "?multiStatements=true")
 	defer db.Close()
 	model.WipeDatabaseWithDb(db, config.DBMigrationsLocation())
+	chapter := model.SFBayChapterIdDevTestStr
 	insertStatement := fmt.Sprintf(`
 INSERT INTO activists
-  (id, name, email, phone, location, activist_level)
+  (chapter_id, id, name, email, phone, location, activist_level)
   VALUES
-  (1, 'Adam Kol', 'test@directactioneverywhere.com', '7035558484', 'Berkeley, United States', 'Supporter'),
-  (2, 'Robin Houseman', 'testtest@gmail.com', '7035558484', 'United States', 'Supporter'),
-  (3, 'aaa', 'test@comcast.net', '7035558484', 'Fairfield, United States', 'Supporter'),
-  (4, 'bbb', '', '7035558484', 'Fairfield, United States', 'Supporter'),
-  (5, 'ccc', 'test@comcast.net', '7035558484', 'Fairfield, United States', 'Supporter'),
-  (100, 'ddd', 'test.test.test@gmail.com', '', 'United States', 'Supporter'),
-  (101, 'eee', 'test.test.test@gmail.com', '', 'United States', 'Supporter'),
-  (102, 'fff', 'test.test.test@gmail.com', '', 'United States', 'Supporter'),
-  (103, 'ggg', 'test.test.test@gmail.com', '', 'United States', 'Supporter'),
-  (104, 'hhh', 'test.test.test@gmail.com', '', 'United States', 'Supporter'),
-  (105, 'iii', 'test.test.test@gmail.com', '', 'United States', 'Supporter'),
-  (106, 'jjj', 'test.test.test@gmail.com', '', 'United States', 'Supporter'),
-  (107, 'lll', 'test.test.test@gmail.com', '', 'United States', 'Supporter'),
-  (108, 'mmm', 'test@gmail.com', '', 'United States', 'Supporter');
+  (`+chapter+`, 1, 'Adam Kol', 'test@directactioneverywhere.com', '7035558484', 'Berkeley, United States', 'Supporter'),
+  (`+chapter+`, 2, 'Robin Houseman', 'testtest@gmail.com', '7035558484', 'United States', 'Supporter'),
+  (`+chapter+`, 3, 'aaa', 'test@comcast.net', '7035558484', 'Fairfield, United States', 'Supporter'),
+  (`+chapter+`, 4, 'bbb', '', '7035558484', 'Fairfield, United States', 'Supporter'),
+  (`+chapter+`, 5, 'ccc', 'test@comcast.net', '7035558484', 'Fairfield, United States', 'Supporter'),
+  (`+chapter+`, 100, 'ddd', 'test.test.test@gmail.com', '', 'United States', 'Supporter'),
+  (`+chapter+`, 101, 'eee', 'test.test.test@gmail.com', '', 'United States', 'Supporter'),
+  (`+chapter+`, 102, 'fff', 'test.test.test@gmail.com', '', 'United States', 'Supporter'),
+  (`+chapter+`, 103, 'ggg', 'test.test.test@gmail.com', '', 'United States', 'Supporter'),
+  (`+chapter+`, 104, 'hhh', 'test.test.test@gmail.com', '', 'United States', 'Supporter'),
+  (`+chapter+`, 105, 'iii', 'test.test.test@gmail.com', '', 'United States', 'Supporter'),
+  (`+chapter+`, 106, 'jjj', 'test.test.test@gmail.com', '', 'United States', 'Supporter'),
+  (`+chapter+`, 107, 'lll', 'test.test.test@gmail.com', '', 'United States', 'Supporter'),
+  (`+chapter+`, 108, 'mmm', 'test@gmail.com', '', 'United States', 'Supporter');
+
+  -- Community prospect test activist
+INSERT INTO activists
+  (chapter_id, id, name, email, phone, location, activist_level, source, interest_date)
+  VALUES
+  (`+chapter+`, 1000, 'nnn', 'test2@gmail.com', '', 'United States', 'Supporter', 'Petition: no-more-bad-things', '`+createCurrentDateString(1)+`');
 
 INSERT INTO events VALUES
   %s

--- a/server/src/main.go
+++ b/server/src/main.go
@@ -652,7 +652,7 @@ func (c MainController) ListCommunityProspectsHandler(w http.ResponseWriter, r *
 		PageName: "CommunityProspects",
 		Data: ActivistListData{
 			Title:       "Community Prospects",
-			Description: "Everyone whose Level is Supporter whose Source is a Petition or Form (excluding Application Form and Check-in Form), has not had an interaction, and has not attended an event within the past year",
+			Description: "Everyone whose Level is Supporter and whose Source is a petition, a form (excluding application forms) or Eventbrite, whose interest date (form submission date) falls within the given date range, and who has not had an interaction, and has not attended an event within the past year",
 			View:        "community_prospects",
 		},
 	})
@@ -1035,7 +1035,7 @@ func (c MainController) ActivistSaveHandler(w http.ResponseWriter, r *http.Reque
 		activistExtra.ChapterID = user.ChapterID
 		activistID, err = model.CreateActivist(c.db, activistExtra)
 	} else {
-		activistID, err = model.UpdateActivistData(c.db, activistExtra, user.Email)
+		activistID, err = model.UserUpdateActivist(c.db, activistExtra, user.Email)
 	}
 	if err != nil {
 		sendErrorMessage(w, err)
@@ -2398,7 +2398,7 @@ func (c MainController) DiscordConfirmHandler(w http.ResponseWriter, r *http.Req
 		// modify the discord_id in the selected activist record
 		activists[0].DiscordID = sql.NullString{String: strings.TrimSpace(strconv.Itoa(user.ID)), Valid: true}
 		// save the updated activist record to the database
-		_, err = model.UpdateActivistData(c.db, activists[0], "SYSTEM")
+		_, err = model.UserUpdateActivist(c.db, activists[0], "SYSTEM")
 		if err != nil {
 			panic(err.Error())
 		}

--- a/server/src/model/activist_test.go
+++ b/server/src/model/activist_test.go
@@ -388,7 +388,7 @@ func TestUpdateActivist(t *testing.T) {
 	activist.Location = sql.NullString{String: "90001", Valid: true}
 	activist.Coords = Coords{1, 2}
 
-	UpdateActivistData(db, *activist, DevTestUserEmail)
+	UserUpdateActivist(db, *activist, DevTestUserEmail)
 
 	updatedActivist, err := GetActivistExtra(db, id)
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes https://app.asana.com/1/71341131816665/project/1204966015842755/task/1211451554791982

A previous simplification of logic to update activists resulted in dev_application_date and dev_application_type fields getting cleared whenever the activist as updated in ADB by a user. These fields were reintroduced to the update query where they were previously excluded, but their values were not set in the CleanActivistData function called from the save handler. This commit adds those fields to the CleanActivistData save handler for completeness, but also removes these fields from the SQL query once again as they should not be editable by the user.