### PR TITLE
chore: remove community prospects csv export

### DIFF
--- a/frontend/ActivistList.vue
+++ b/frontend/ActivistList.vue
@@ -89,15 +89,6 @@
             :href="`/csv/new_activists_pending_workshop_spoke?start_date=${lastEventDateFrom}&end_date=${lastEventDateTo}`"
           ></b-button>
         </div>
-        <div class="level-item px-1" v-if="view === 'community_prospects'">
-          <b-button
-            label="Export CSV for HubSpot"
-            type="is-info"
-            icon-left="download"
-            tag="a"
-            href="/csv/community_prospects_hubspot"
-          ></b-button>
-        </div>
         <div class="level-item has-text-centered px-1">
           <div>
             <p class="heading">Total</p>

--- a/server/src/main.go
+++ b/server/src/main.go
@@ -307,7 +307,6 @@ func router() (*mux.Router, *sqlx.DB) {
 	router.Handle("/interaction/list", alice.New(main.apiAttendanceAuthMiddleware).ThenFunc(main.InteractionListHandler))
 	router.Handle("/interaction/delete", alice.New(main.apiOrganizerAuthMiddleware).ThenFunc(main.InteractionDeleteHandler))
 	router.Handle("/csv/chapter_member_spoke", alice.New(main.apiOrganizerOrNonSFBayAuthMiddleware).ThenFunc(main.ChapterMemberSpokeCSVHandler))
-	router.Handle("/csv/community_prospects_hubspot", alice.New(main.apiOrganizerOrNonSFBayAuthMiddleware).ThenFunc(main.CommunityProspectHubSpotCSVHandler))
 	router.Handle("/csv/international_organizers", alice.New(main.apiOrganizerAuthMiddleware).ThenFunc(main.InternationalOrganizersCSVHandler))
 	router.Handle("/csv/event_attendance/{event_id:[0-9]+}", alice.New(main.apiOrganizerOrNonSFBayAuthMiddleware).ThenFunc(main.EventAttendanceCSVHandler))
 	router.Handle("/csv/all_activists_spoke", alice.New(main.apiOrganizerOrNonSFBayAuthMiddleware).ThenFunc(main.SupporterSpokeCSVHandler))
@@ -1584,36 +1583,6 @@ func (c MainController) NewActivistsPendingWorkshopSpokeCSVHandler(w http.Respon
 		}
 	}
 	writer.Flush()
-}
-
-func (c MainController) CommunityProspectHubSpotCSVHandler(w http.ResponseWriter, r *http.Request) {
-	chapter := getAuthedADBChapter(c.db, r)
-
-	activists, err := model.GetCommunityProspectHubSpotInfo(c.db, chapter)
-	if err != nil {
-		sendErrorMessage(w, err)
-		return
-	}
-
-	w.Header().Set("Content-Disposition", "attachment; filename=community_prospects.csv")
-	w.Header().Set("Content-Type", "text/csv")
-	w.Header().Set("Transfer-Encoding", "chunked")
-
-	writer := csv.NewWriter(w)
-	err = writer.Write([]string{"first_name", "last_name", "email", "phone", "zip", "source", "interest_date"})
-	if err != nil {
-		sendErrorMessage(w, err)
-		return
-	}
-	for _, activist := range activists {
-		err := writer.Write([]string{activist.FirstName, activist.LastName, activist.Email, activist.Phone, activist.Zip, activist.Source, activist.InterestDate})
-		if err != nil {
-			sendErrorMessage(w, err)
-			return
-		}
-	}
-	writer.Flush()
-
 }
 
 func (c MainController) InternationalOrganizersCSVHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
The SQL query behind it was outdated (did not match the list generated in the UI) and it seems no one uses it.