### PR TITLE
feat: overhaul date-picker with input mask and segment editing

### DIFF
--- a/frontend-v2/src/app/(authed)/activists/filters/filter-chip.tsx
+++ b/frontend-v2/src/app/(authed)/activists/filters/filter-chip.tsx
@@ -97,7 +97,12 @@ export function FilterChip({
             )}
           </button>
         </PopoverTrigger>
-        <PopoverContent className={popoverClassName ?? 'w-64'}>
+        <PopoverContent
+          className={popoverClassName ?? 'w-64'}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') handleOpenChange(false)
+          }}
+        >
           {children}
         </PopoverContent>
       </Popover>

--- a/frontend-v2/src/components/ui/README.md
+++ b/frontend-v2/src/components/ui/README.md
@@ -8,9 +8,17 @@ When upgrading shadcn components, preserve the following customizations:
 
 ### date-picker.tsx
 
-Changed the date display format from `PPP` (e.g. "January 1st, 2025") to `PP` (e.g. "Jan 1, 2025") so the selected date fits in narrow inputs without overflow. Also added `truncate` to the label span and `shrink-0` to the calendar icon to handle any remaining overflow gracefully.
+Completely rewritten from the default shadcn button-trigger implementation. The original rendered a `<Button>` that opened a calendar popover; this version replaces it with a masked text input so users can type or pick a date.
 
-The popover is controlled (`open` state) so it closes automatically when a date is selected.
+Key changes:
+
+- **Input mask** — the input always shows `MM/DD/YYYY` as a template. Digit slots are tracked internally as a fixed 8-character string (`'_'` = unfilled). `buildMasked` maps slots to the display string; `displayCursorToDigitCursor` maps display cursor positions back to slot indices for keyboard handling.
+- **Segment editing** — double-clicking a segment (month/day/year) selects it; the next digit typed fills from the start of that segment and clears the rest, so adjacent segments never bleed in. The compact-string approach of the original would have caused this bleed.
+- **Overwrite mode** — typing with a cursor (no selection) overwrites the slot under the cursor and advances, matching standard input-mask UX.
+- **Calendar icon on the left** — positioned with `absolute left-3`; the input uses `style={{ paddingLeft: '2.5rem' }}` (inline style) rather than a Tailwind class because `@tailwindcss/forms` injects unlayered global padding on `input` elements that beats Tailwind utility classes regardless of specificity.
+- **Cursor placement via `useLayoutEffect`** — a `pendingCursorRef` is set by `moveCursor()` and applied in `useLayoutEffect` (before paint) to avoid the one-frame cursor-reset flicker that `setTimeout` caused.
+- **Popover wiring** — uses `PopoverAnchor` instead of `PopoverTrigger` so the input (not the icon button) acts as the anchor. `onOpenAutoFocus` and `onMouseDown` on the content prevent Radix from stealing focus from the input. `skipNextOpenRef` prevents the calendar from re-opening when focus returns after a date is selected or the icon is clicked.
+- **Enter key** — closes the inner calendar without propagating to outer forms; `e.stopPropagation()` is called so a parent `FilterChip` popover can independently handle Enter to commit its own draft.
 
 ### select.tsx
 

--- a/frontend-v2/src/components/ui/date-picker.tsx
+++ b/frontend-v2/src/components/ui/date-picker.tsx
@@ -1,14 +1,10 @@
 'use client'
 
 import * as React from 'react'
-import { Button } from '@/components/ui/button'
 import { Calendar } from '@/components/ui/calendar'
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover'
-import { format } from 'date-fns'
+import { Input } from '@/components/ui/input'
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
+import { format, isValid, parse } from 'date-fns'
 import { CalendarIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
@@ -20,43 +16,317 @@ export interface DatePickerProps {
   disabled?: boolean
 }
 
+const PARSE_FORMATS = [
+  'MM/dd/yyyy',
+  'M/d/yyyy',
+  'MM-dd-yyyy',
+  'M-d-yyyy',
+  'yyyy-MM-dd',
+]
+
+function parseDate(str: string): Date | undefined {
+  for (const fmt of PARSE_FORMATS) {
+    const parsed = parse(str, fmt, new Date())
+    if (isValid(parsed)) return parsed
+  }
+  return undefined
+}
+
+const DISPLAY_FORMAT = 'MM/dd/yyyy'
+
+// Fixed 8-slot string; '_' means the slot has not been filled yet.
+// Slots: [M0 M1 D0 D1 Y0 Y1 Y2 Y3]
+const EMPTY_DIGITS = '________'
+
+function buildMasked(digits: string): string {
+  const ph = ['M', 'M', 'D', 'D', 'Y', 'Y', 'Y', 'Y']
+  const d = (i: number) => (digits[i] !== '_' ? digits[i] : ph[i])
+  return `${d(0)}${d(1)}/${d(2)}${d(3)}/${d(4)}${d(5)}${d(6)}${d(7)}`
+}
+
+// Maps digit slot index (0–8) to display cursor position (0–10).
+function cursorPos(n: number): number {
+  if (n <= 2) return n
+  if (n <= 4) return n + 1
+  return n + 2
+}
+
+// Maps display cursor position (0–10) to digit slot index (0–8).
+// Display: M M / D D / Y Y Y Y  (chars 0–9, cursor positions 0–10)
+function displayCursorToDigitCursor(pos: number): number {
+  if (pos <= 2) return pos
+  if (pos <= 5) return pos - 1
+  return pos - 2
+}
+
+function extractDigits(str: string): string {
+  return str.replace(/\D/g, '').slice(0, 8)
+}
+
+function fromDate(date: Date): string {
+  return extractDigits(format(date, DISPLAY_FORMAT))
+}
+
 export function DatePicker({
   value,
   onValueChange,
-  placeholder = 'Pick a date',
+  placeholder = 'MM/DD/YYYY',
   className,
   disabled,
 }: DatePickerProps) {
   const [open, setOpen] = React.useState(false)
+  const [digits, setDigits] = React.useState(
+    value ? fromDate(value) : EMPTY_DIGITS,
+  )
+  const [calendarMonth, setCalendarMonth] = React.useState<Date | undefined>(
+    value,
+  )
+  const [isFocused, setIsFocused] = React.useState(false)
+  const inputRef = React.useRef<HTMLInputElement>(null)
+  const containerRef = React.useRef<HTMLDivElement>(null)
+  const skipNextOpenRef = React.useRef(false)
+  const pendingCursorRef = React.useRef<number | null>(null)
+
+  // Sync when value changes externally (e.g. parent resets form).
+  React.useEffect(() => {
+    if (!isFocused) {
+      setDigits(value ? fromDate(value) : EMPTY_DIGITS)
+      if (value) setCalendarMonth(value)
+    }
+  }, [value, isFocused])
+
+  // Apply pending cursor position after DOM update, before paint.
+  React.useLayoutEffect(() => {
+    if (pendingCursorRef.current !== null) {
+      inputRef.current?.setSelectionRange(
+        pendingCursorRef.current,
+        pendingCursorRef.current,
+      )
+      pendingCursorRef.current = null
+    }
+  })
+
+  const displayValue =
+    isFocused || digits !== EMPTY_DIGITS ? buildMasked(digits) : ''
+
+  function moveCursor(n: number) {
+    pendingCursorRef.current = cursorPos(n)
+  }
+
+  function isAllSelected(): boolean {
+    const el = inputRef.current
+    return (
+      !!el && el.selectionStart === 0 && el.selectionEnd === el.value.length
+    )
+  }
+
+  function getSelectionDigitRange(): { dStart: number; dEnd: number } | null {
+    const el = inputRef.current
+    if (!el) return null
+    const s = el.selectionStart ?? 8
+    const e = el.selectionEnd ?? 8
+    if (s === e) return null
+    return {
+      dStart: displayCursorToDigitCursor(s),
+      dEnd: displayCursorToDigitCursor(e),
+    }
+  }
+
+  function commitDigits(d: string) {
+    setDigits(d)
+    if (!d.includes('_')) {
+      const parsed = parseDate(buildMasked(d))
+      if (parsed) {
+        onValueChange?.(parsed)
+        setCalendarMonth(parsed)
+      }
+    } else if (d === EMPTY_DIGITS) {
+      onValueChange?.(undefined)
+    }
+  }
+
+  function resetToLastValid() {
+    setDigits(value ? fromDate(value) : EMPTY_DIGITS)
+  }
+
+  function closeAndReset() {
+    setOpen(false)
+    const isComplete = !digits.includes('_') && !!parseDate(buildMasked(digits))
+    const isEmpty = digits === EMPTY_DIGITS
+    if (!isComplete && !isEmpty) resetToLastValid()
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.ctrlKey || e.metaKey) return
+
+    if (e.key === 'Enter') {
+      if (open) {
+        e.preventDefault()
+        e.stopPropagation()
+        closeAndReset()
+      }
+      return
+    }
+
+    if (e.key >= '0' && e.key <= '9') {
+      e.preventDefault()
+      if (isAllSelected()) {
+        commitDigits(e.key + EMPTY_DIGITS.slice(1))
+        moveCursor(1)
+      } else {
+        const sel = getSelectionDigitRange()
+        if (sel) {
+          // Fill from the start of the selection, clear the rest of the
+          // selected range so adjacent segments don't bleed in.
+          const segLen = sel.dEnd - sel.dStart
+          const next =
+            digits.slice(0, sel.dStart) +
+            e.key +
+            '_'.repeat(segLen - 1) +
+            digits.slice(sel.dEnd)
+          commitDigits(next)
+          moveCursor(sel.dStart + 1)
+        } else {
+          // Overwrite at cursor: replaces the slot under the cursor.
+          const displayPos = inputRef.current?.selectionStart ?? cursorPos(8)
+          const dPos = displayCursorToDigitCursor(displayPos)
+          if (dPos < 8) {
+            const next = digits.slice(0, dPos) + e.key + digits.slice(dPos + 1)
+            commitDigits(next)
+            moveCursor(dPos + 1)
+          }
+        }
+      }
+    } else if (e.key === 'Backspace') {
+      e.preventDefault()
+      if (isAllSelected()) {
+        commitDigits(EMPTY_DIGITS)
+        moveCursor(0)
+      } else {
+        const sel = getSelectionDigitRange()
+        if (sel) {
+          const segLen = sel.dEnd - sel.dStart
+          const next =
+            digits.slice(0, sel.dStart) +
+            '_'.repeat(segLen) +
+            digits.slice(sel.dEnd)
+          commitDigits(next)
+          moveCursor(sel.dStart)
+        } else {
+          // Clear the slot just before the cursor.
+          const displayPos = inputRef.current?.selectionStart ?? 0
+          const dPos = displayCursorToDigitCursor(displayPos)
+          if (dPos > 0) {
+            const target = dPos - 1
+            const next =
+              digits.slice(0, target) + '_' + digits.slice(target + 1)
+            commitDigits(next)
+            moveCursor(target)
+          }
+        }
+      }
+    } else if (e.key === 'Delete') {
+      e.preventDefault()
+      commitDigits(EMPTY_DIGITS)
+      moveCursor(0)
+    } else if (e.key.length === 1) {
+      e.preventDefault()
+    }
+  }
+
+  // Handles paste via onChange (keydown e.preventDefault suppresses normal input).
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const raw = extractDigits(e.target.value)
+    const padded = (raw + EMPTY_DIGITS).slice(0, 8)
+    commitDigits(padded)
+    moveCursor(Math.min(raw.length, 8))
+  }
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          disabled={disabled}
-          className={cn(
-            'w-full justify-start text-left font-normal shadow-none bg-transparent hover:!bg-transparent hover:border-gray-400 focus:border-primary focus-visible:border-primary focus:hover:border-primary focus-visible:hover:border-primary',
-            !value && 'text-muted-foreground hover:!text-muted-foreground',
-            value && 'hover:!text-current',
-            className,
-          )}
-        >
-          <CalendarIcon className="mr-2 h-4 w-4 shrink-0" />
-          <span className="truncate">
-            {value ? format(value, 'PP') : placeholder}
-          </span>
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-auto p-0" align="start">
+      <PopoverAnchor asChild>
+        <div ref={containerRef} className={cn('relative', className)}>
+          <Input
+            ref={inputRef}
+            value={displayValue}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            onClick={() => {
+              if (!disabled) setOpen(true)
+            }}
+            onFocus={() => {
+              setIsFocused(true)
+              const n = digits.indexOf('_')
+              moveCursor(n === -1 ? 8 : n)
+              if (skipNextOpenRef.current) {
+                skipNextOpenRef.current = false
+                return
+              }
+              if (!disabled) setOpen(true)
+            }}
+            onBlur={() => {
+              setIsFocused(false)
+              // Reset partial/invalid input when calendar is also closed.
+              if (!open) {
+                const isComplete =
+                  !digits.includes('_') && !!parseDate(buildMasked(digits))
+                const isEmpty = digits === EMPTY_DIGITS
+                if (!isComplete && !isEmpty) resetToLastValid()
+              }
+            }}
+            disabled={disabled}
+            placeholder={placeholder}
+            style={{ paddingLeft: '2.5rem' }}
+          />
+          <button
+            type="button"
+            disabled={disabled}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => {
+              if (!disabled) {
+                setOpen((prev) => !prev)
+                skipNextOpenRef.current = true
+                inputRef.current?.focus()
+              }
+            }}
+            className="absolute inset-y-0 left-3 flex items-center text-muted-foreground hover:text-foreground disabled:opacity-50"
+            tabIndex={-1}
+          >
+            <CalendarIcon className="h-4 w-4" />
+          </button>
+        </div>
+      </PopoverAnchor>
+      <PopoverContent
+        className="w-auto p-0"
+        align="start"
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        onMouseDown={(e) => e.preventDefault()}
+        onInteractOutside={(e) => {
+          // Don't dismiss when interacting with the input/icon — we manage that ourselves.
+          if (containerRef.current?.contains(e.target as Node)) {
+            e.preventDefault()
+          }
+        }}
+        onFocusOutside={(e) => {
+          if (containerRef.current?.contains(e.target as Node)) {
+            e.preventDefault()
+          }
+        }}
+        onEscapeKeyDown={() => closeAndReset()}
+      >
         <Calendar
           mode="single"
           selected={value}
+          month={calendarMonth}
+          onMonthChange={setCalendarMonth}
           onSelect={(date) => {
             onValueChange?.(date)
+            setDigits(date ? fromDate(date) : EMPTY_DIGITS)
+            if (date) setCalendarMonth(date)
             setOpen(false)
+            skipNextOpenRef.current = true
+            inputRef.current?.focus()
           }}
-          defaultMonth={value}
         />
       </PopoverContent>
     </Popover>


### PR DESCRIPTION
Replace button trigger with a text input showing MM/DD/YYYY mask. Calendar icon moved to left side of input; inline style for left padding avoids specificity conflicts with @tailwindcss/forms.

Fixed-width 8-slot digit state ('_' for empty) keeps segments isolated so typing into month/day/year never bleeds into adjacent segments, including when double-clicking to select a segment. Overwrite-at-cursor mode; segment selection clears only that segment's remaining slots so '2M/DD/YYYY' not '21/DD/YYYY'.

useLayoutEffect replaces setTimeout for cursor placement, eliminating the one-frame cursor-reset flicker on each keystroke.

Calendar auto-navigates to the month as the date is typed. Enter closes the inner calendar without submitting the outer form. FilterChip popover now closes on Enter, triggering useDraftFilter to commit the draft (fixes date filter not saving on Enter on the activists page). Tab into the field opens the calendar.