### PR TITLE
fix(users): SSR issue

### DIFF
--- a/frontend-v2/src/app/(authed)/users/[id]/page.tsx
+++ b/frontend-v2/src/app/(authed)/users/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import {
   dehydrate,
   HydrationBoundary,
@@ -8,6 +9,7 @@ import { ContentWrapper } from '@/app/content-wrapper'
 import { API_PATH, ApiClient } from '@/lib/api'
 import { getCookies } from '@/lib/auth'
 import { redirectForHttpError } from '@/lib/server-auth'
+import { FormLoadingFallback } from '../form-loading-fallback'
 import { UserForm } from '../user-form'
 
 export default async function EditUserPage({
@@ -42,7 +44,9 @@ export default async function EditUserPage({
   return (
     <ContentWrapper size="lg" className="gap-6">
       <HydrationBoundary state={dehydrate(queryClient)}>
-        <UserForm userId={userId} />
+        <Suspense fallback={<FormLoadingFallback />}>
+          <UserForm userId={userId} />
+        </Suspense>
       </HydrationBoundary>
     </ContentWrapper>
   )

--- a/frontend-v2/src/app/(authed)/users/form-loading-fallback.tsx
+++ b/frontend-v2/src/app/(authed)/users/form-loading-fallback.tsx
@@ -1,0 +1,10 @@
+import { Loader2 } from 'lucide-react'
+
+export function FormLoadingFallback() {
+  return (
+    <div className="flex items-center gap-2 text-muted-foreground text-sm">
+      <Loader2 className="h-4 w-4 animate-spin" />
+      Loading...
+    </div>
+  )
+}

--- a/frontend-v2/src/app/(authed)/users/new/page.tsx
+++ b/frontend-v2/src/app/(authed)/users/new/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import {
   dehydrate,
   HydrationBoundary,
@@ -7,6 +8,7 @@ import { ContentWrapper } from '@/app/content-wrapper'
 import { API_PATH, ApiClient } from '@/lib/api'
 import { getCookies } from '@/lib/auth'
 import { redirectForHttpError } from '@/lib/server-auth'
+import { FormLoadingFallback } from '../form-loading-fallback'
 import { UserForm } from '../user-form'
 
 export default async function NewUserPage() {
@@ -24,7 +26,9 @@ export default async function NewUserPage() {
   return (
     <ContentWrapper size="lg" className="gap-6">
       <HydrationBoundary state={dehydrate(queryClient)}>
-        <UserForm />
+        <Suspense fallback={<FormLoadingFallback />}>
+          <UserForm />
+        </Suspense>
       </HydrationBoundary>
     </ContentWrapper>
   )

--- a/frontend-v2/src/app/(authed)/users/user-form.tsx
+++ b/frontend-v2/src/app/(authed)/users/user-form.tsx
@@ -4,7 +4,11 @@ import Link from 'next/link'
 import { useMemo } from 'react'
 import { useForm } from '@tanstack/react-form'
 import { z } from 'zod'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  useMutation,
+  useSuspenseQuery,
+  useQueryClient,
+} from '@tanstack/react-query'
 import { useRouter } from 'next/navigation'
 import toast from 'react-hot-toast'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -18,7 +22,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { API_PATH, apiClient, Role, User, UserWithoutId } from '@/lib/api'
+import {
+  API_PATH,
+  apiClient,
+  Chapter,
+  Role,
+  User,
+  UserWithoutId,
+} from '@/lib/api'
 import { formatRoleLabel } from '@/lib/roles'
 import { Loader2, Save, ArrowLeft } from 'lucide-react'
 
@@ -39,32 +50,17 @@ const userFormSubmitSchema = userFormSchema.extend({
 
 type UserFormValues = z.infer<typeof userFormSchema>
 
-export function UserForm({ userId }: { userId?: number }) {
+function UserFormInner({
+  userId,
+  user,
+  chapters,
+}: {
+  userId?: number
+  user: User | undefined
+  chapters: Chapter[]
+}) {
   const router = useRouter()
   const queryClient = useQueryClient()
-
-  const {
-    data: chapters,
-    isLoading: isChaptersLoading,
-    isError: isChaptersError,
-    error: chaptersError,
-  } = useQuery({
-    queryKey: [API_PATH.CHAPTER_LIST],
-    queryFn: ({ signal }) => apiClient.getChapterList(signal),
-  })
-
-  const {
-    data: user,
-    isLoading: userLoading,
-    isError: userError,
-    error: userErrorObj,
-  } = useQuery<User | undefined>({
-    queryKey: [API_PATH.USERS, userId],
-    queryFn: userId
-      ? ({ signal }) => apiClient.getUser(userId, signal)
-      : async () => undefined,
-    enabled: !!userId,
-  })
 
   const mutation = useMutation({
     mutationFn: async (payload: UserWithoutId) => {
@@ -122,36 +118,6 @@ export function UserForm({ userId }: { userId?: number }) {
 
   const isSubmitting = mutation.isPending
 
-  const isLoading = isChaptersLoading || userLoading
-  const loadError = isChaptersError || userError
-  const loadErrorMessage =
-    (chaptersError as Error | undefined)?.message ||
-    (userErrorObj as Error | undefined)?.message ||
-    'Failed to load user data.'
-  if (loadError) {
-    return (
-      <div className="space-y-3">
-        <div className="flex items-start justify-between gap-2">
-          <div className="flex flex-col gap-1">
-            <p className="text-sm uppercase tracking-wide text-muted-foreground">
-              {userId ? 'Edit user' : 'Create user'}
-            </p>
-            <h1 className="text-2xl font-semibold">Users</h1>
-          </div>
-          <Button variant="ghost" asChild>
-            <Link href="/users">
-              <ArrowLeft className="h-4 w-4" />
-              Back to list
-            </Link>
-          </Button>
-        </div>
-        <div className="rounded-md border p-4 text-sm text-destructive">
-          {loadErrorMessage}
-        </div>
-      </div>
-    )
-  }
-
   return (
     <div className="flex flex-col gap-6">
       <div className="flex items-start justify-between gap-2">
@@ -159,11 +125,7 @@ export function UserForm({ userId }: { userId?: number }) {
           <p className="text-sm uppercase tracking-wide text-muted-foreground">
             {userId ? 'Edit user' : 'Create user'}
           </p>
-          {!userLoading && (
-            <h1 className="text-2xl font-semibold">
-              {user?.name ?? 'New User'}
-            </h1>
-          )}
+          <h1 className="text-2xl font-semibold">{user?.name ?? 'New User'}</h1>
         </div>
         <Button variant="ghost" asChild>
           <Link href="/users">
@@ -173,167 +135,41 @@ export function UserForm({ userId }: { userId?: number }) {
         </Button>
       </div>
 
-      {isLoading && (
-        <div className="flex items-center gap-2 text-muted-foreground text-sm">
-          <Loader2 className="h-4 w-4 animate-spin" />
-          Loading...
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          form.handleSubmit()
+        }}
+        className="space-y-6"
+      >
+        <div className="flex items-center justify-end">
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              <>
+                <Save className="h-4 w-4" />
+                Save user
+              </>
+            )}
+          </Button>
         </div>
-      )}
 
-      {!isLoading && (
-        <form
-          onSubmit={(e) => {
-            e.preventDefault()
-            form.handleSubmit()
-          }}
-          className="space-y-6"
-        >
-          <div className="flex items-center justify-end">
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? (
-                <>
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  Saving...
-                </>
-              ) : (
-                <>
-                  <Save className="h-4 w-4" />
-                  Save user
-                </>
-              )}
-            </Button>
-          </div>
-
-          <div className="grid gap-4 md:grid-cols-2">
-            <form.Field name="name">
-              {(field) => (
-                <div className="space-y-1">
-                  <Label htmlFor="user-name">Name</Label>
-                  <Input
-                    id="user-name"
-                    value={field.state.value}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                    onBlur={field.handleBlur}
-                    placeholder="Full name"
-                  />
-                  {field.state.meta.errors[0] && (
-                    <p className="text-sm text-destructive">
-                      {field.state.meta.errors[0]?.message}
-                    </p>
-                  )}
-                </div>
-              )}
-            </form.Field>
-
-            <form.Field name="email">
-              {(field) => (
-                <div className="space-y-1">
-                  <Label htmlFor="user-email">Email</Label>
-                  <Input
-                    id="user-email"
-                    type="email"
-                    value={field.state.value}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                    onBlur={field.handleBlur}
-                    placeholder="user@example.org"
-                  />
-                  {field.state.meta.errors[0] && (
-                    <p className="text-sm text-destructive">
-                      {field.state.meta.errors[0]?.message}
-                    </p>
-                  )}
-                </div>
-              )}
-            </form.Field>
-
-            <form.Field name="chapterId">
-              {(field) => (
-                <div className="space-y-1">
-                  <Label htmlFor="user-chapter">Chapter</Label>
-                  <Select
-                    value={
-                      field.state.value !== null
-                        ? String(field.state.value)
-                        : ''
-                    }
-                    onValueChange={(value: string) => {
-                      const next = parseInt(value, 10)
-                      field.handleChange(Number.isNaN(next) ? null : next)
-                    }}
-                    disabled={isChaptersLoading}
-                  >
-                    <SelectTrigger id="user-chapter">
-                      <SelectValue placeholder="Select a chapter" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {chapters?.map((chapter) => (
-                        <SelectItem
-                          key={chapter.ChapterID}
-                          value={String(chapter.ChapterID)}
-                        >
-                          {chapter.Name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  {field.state.meta.errors[0] && (
-                    <p className="text-sm text-destructive">
-                      {field.state.meta.errors[0]?.message}
-                    </p>
-                  )}
-                </div>
-              )}
-            </form.Field>
-
-            <form.Field name="disabled">
-              {(field) => (
-                <div className="space-y-2 rounded-md border p-3">
-                  <Label className="flex items-center gap-2 text-sm">
-                    <Checkbox
-                      checked={field.state.value}
-                      onCheckedChange={(checked: boolean | 'indeterminate') =>
-                        field.handleChange(Boolean(checked))
-                      }
-                    />
-                    Disabled
-                  </Label>
-                  <p className="text-xs text-muted-foreground">
-                    Disabled users cannot sign in. Use this to suspend access
-                    without deleting their account.
-                  </p>
-                </div>
-              )}
-            </form.Field>
-          </div>
-
-          <form.Field name="roles">
+        <div className="grid gap-4 md:grid-cols-2">
+          <form.Field name="name">
             {(field) => (
-              <div className="space-y-2">
-                <Label>Roles</Label>
-                <div className="flex max-w-xs flex-col gap-2">
-                  {Role.options.map((role) => {
-                    const checked = field.state.value.includes(role)
-                    return (
-                      <label
-                        key={role}
-                        className="flex w-full items-center gap-2 rounded-md border p-3 text-sm"
-                      >
-                        <Checkbox
-                          checked={checked}
-                          onCheckedChange={() => {
-                            const nextRoles = checked
-                              ? field.state.value.filter((r) => r !== role)
-                              : [...field.state.value, role]
-                            field.handleChange(nextRoles)
-                          }}
-                        />
-                        <span className="capitalize">
-                          {formatRoleLabel(role)}
-                        </span>
-                      </label>
-                    )
-                  })}
-                </div>
+              <div className="space-y-1">
+                <Label htmlFor="user-name">Name</Label>
+                <Input
+                  id="user-name"
+                  value={field.state.value}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                  onBlur={field.handleBlur}
+                  placeholder="Full name"
+                />
                 {field.state.meta.errors[0] && (
                   <p className="text-sm text-destructive">
                     {field.state.meta.errors[0]?.message}
@@ -342,8 +178,149 @@ export function UserForm({ userId }: { userId?: number }) {
               </div>
             )}
           </form.Field>
-        </form>
-      )}
+
+          <form.Field name="email">
+            {(field) => (
+              <div className="space-y-1">
+                <Label htmlFor="user-email">Email</Label>
+                <Input
+                  id="user-email"
+                  type="email"
+                  value={field.state.value}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                  onBlur={field.handleBlur}
+                  placeholder="user@example.org"
+                />
+                {field.state.meta.errors[0] && (
+                  <p className="text-sm text-destructive">
+                    {field.state.meta.errors[0]?.message}
+                  </p>
+                )}
+              </div>
+            )}
+          </form.Field>
+
+          <form.Field name="chapterId">
+            {(field) => (
+              <div className="space-y-1">
+                <Label htmlFor="user-chapter">Chapter</Label>
+                <Select
+                  value={
+                    field.state.value !== null ? String(field.state.value) : ''
+                  }
+                  onValueChange={(value: string) => {
+                    const next = parseInt(value, 10)
+                    field.handleChange(Number.isNaN(next) ? null : next)
+                  }}
+                >
+                  <SelectTrigger id="user-chapter">
+                    <SelectValue placeholder="Select a chapter" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {chapters.map((chapter) => (
+                      <SelectItem
+                        key={chapter.ChapterID}
+                        value={String(chapter.ChapterID)}
+                      >
+                        {chapter.Name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {field.state.meta.errors[0] && (
+                  <p className="text-sm text-destructive">
+                    {field.state.meta.errors[0]?.message}
+                  </p>
+                )}
+              </div>
+            )}
+          </form.Field>
+
+          <form.Field name="disabled">
+            {(field) => (
+              <div className="space-y-2 rounded-md border p-3">
+                <Label className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={field.state.value}
+                    onCheckedChange={(checked: boolean | 'indeterminate') =>
+                      field.handleChange(Boolean(checked))
+                    }
+                  />
+                  Disabled
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Disabled users cannot sign in. Use this to suspend access
+                  without deleting their account.
+                </p>
+              </div>
+            )}
+          </form.Field>
+        </div>
+
+        <form.Field name="roles">
+          {(field) => (
+            <div className="space-y-2">
+              <Label>Roles</Label>
+              <div className="flex max-w-xs flex-col gap-2">
+                {Role.options.map((role) => {
+                  const checked = field.state.value.includes(role)
+                  return (
+                    <label
+                      key={role}
+                      className="flex w-full items-center gap-2 rounded-md border p-3 text-sm"
+                    >
+                      <Checkbox
+                        checked={checked}
+                        onCheckedChange={() => {
+                          const nextRoles = checked
+                            ? field.state.value.filter((r) => r !== role)
+                            : [...field.state.value, role]
+                          field.handleChange(nextRoles)
+                        }}
+                      />
+                      <span className="capitalize">
+                        {formatRoleLabel(role)}
+                      </span>
+                    </label>
+                  )
+                })}
+              </div>
+              {field.state.meta.errors[0] && (
+                <p className="text-sm text-destructive">
+                  {field.state.meta.errors[0]?.message}
+                </p>
+              )}
+            </div>
+          )}
+        </form.Field>
+      </form>
     </div>
   )
+}
+
+function EditUserForm({
+  userId,
+  chapters,
+}: {
+  userId: number
+  chapters: Chapter[]
+}) {
+  const { data: user } = useSuspenseQuery({
+    queryKey: [API_PATH.USERS, userId],
+    queryFn: ({ signal }) => apiClient.getUser(userId, signal),
+  })
+  return <UserFormInner userId={userId} user={user} chapters={chapters} />
+}
+
+export function UserForm({ userId }: { userId?: number }) {
+  const { data: chapters } = useSuspenseQuery({
+    queryKey: [API_PATH.CHAPTER_LIST],
+    queryFn: ({ signal }) => apiClient.getChapterList(signal),
+  })
+
+  if (userId) {
+    return <EditUserForm userId={userId} chapters={chapters} />
+  }
+
+  return <UserFormInner chapters={chapters} user={undefined} />
 }

--- a/frontend-v2/src/app/(authed)/users/user-table.tsx
+++ b/frontend-v2/src/app/(authed)/users/user-table.tsx
@@ -9,7 +9,7 @@ import {
   SortingState,
   useReactTable,
 } from '@tanstack/react-table'
-import { User } from '@/lib/api'
+import { Chapter, User } from '@/lib/api'
 import {
   Table,
   TableBody,
@@ -24,11 +24,6 @@ import { Pencil } from 'lucide-react'
 import clsx from 'clsx'
 import { SortIndicator } from '@/components/ui/sort-indicator'
 import { formatRoleLabel } from '@/lib/roles'
-
-type Chapter = {
-  ChapterID: number
-  Name: string
-}
 
 export function UserTable({
   users,

--- a/frontend-v2/src/lib/api.ts
+++ b/frontend-v2/src/lib/api.ts
@@ -87,6 +87,7 @@ const ChapterOrganizerSchema = z.object({
   Linkedin: z.string().optional(),
 })
 export type ChapterOrganizer = z.infer<typeof ChapterOrganizerSchema>
+export type Chapter = z.infer<typeof ChapterListResp>['chapters'][number]
 
 const ChapterWithOrganizersSchema = z.object({
   ChapterID: z.number(),


### PR DESCRIPTION
Switch to useSuspenseQuery and add a <Suspense fallback={...}> in page.tsx

Hydration error was caused by user-form.tsx:176-190:

```
{isLoading && (
  <div className="flex items-center gap-2 text-muted-foreground text-sm">
    ...
  </div>
)}
{!isLoading && (
  <form ...>
```

Server renders the <div> (loading state). Client renders the <form>.
React sees different DOM trees → hydration error.

Why they differ: During Next.js SSR of UserForm (a client component),
the Providers component (see providers.tsx:40-42) creates a fresh, empty
QueryClient on the server (isServer = true → makeQueryClient() on every
call). Even though HydrationBoundary is supposed to inject data into
that client via useMemo before UserForm renders, in practice the
TanStack Query hooks in UserForm see isLoading: true during the server
pass — the queries are in a pending/fetching state.

On the client side, HydrationBoundary successfully rehydrates the
singleton browser QueryClient with the prefetched data, so isLoading is
false and the form renders.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added animated loading spinners on user edit and new user creation pages that display while forms initialize and load their data.

* **Improvements**
  * Enhanced form submission behavior with improved interaction handling.
  * Optimized the user information form component with better data loading management for user details and chapter selections throughout the form lifecycle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxe/adb/pull/421?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->