### PR TITLE
feat(devcontainer): publish app port to host for CLI workflows

### DIFF
--- a/.devcontainer/write-workspace-compose.sh
+++ b/.devcontainer/write-workspace-compose.sh
@@ -19,6 +19,26 @@ workspace_name="$(basename "${workspace_path}")"
 sanitized_workspace_name="$(printf '%s' "${workspace_name}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-')"
 project_name="dxe-adb-${sanitized_workspace_name}"
 
+# Publish the Go server's port (8080 inside the container) to the host. The
+# devcontainer CLI ignores devcontainer.json's "forwardPorts" (that is a VS Code
+# editor feature, not part of the devcontainer spec), so for CLI users we publish
+# at the Docker layer here instead. Each worktree gets a distinct host port to
+# avoid collisions when several run in parallel: honor ADB_HOST_PORT when set,
+# otherwise derive a stable port from the workspace name.
+if [[ -n "${ADB_HOST_PORT:-}" ]]; then
+  host_port="${ADB_HOST_PORT}"
+  # When a host port is pinned via ADB_HOST_PORT, the app is expected to run with
+  # PORT set to the same value, so publish host->container 1:1. This keeps the
+  # port the Go server logs identical to the reachable host port (some tools pick
+  # the URL to open by parsing the server's stdout).
+  container_port="${ADB_HOST_PORT}"
+else
+  name_hash="$(printf '%s' "${sanitized_workspace_name}" | cksum | cut -d' ' -f1)"
+  host_port=$(( 20000 + (name_hash % 20000) ))
+  container_port=8080
+fi
+echo "write-workspace-compose: publishing container port ${container_port} on host port ${host_port}" >&2
+
 # Ask git where it stores its data. For a normal repo these two paths are the
 # same. For a git worktree they differ: git-dir points to a worktree-specific
 # stub, while git-common-dir points to the main repo's .git where objects and
@@ -38,6 +58,8 @@ name: ${project_name}
 
 services:
   devcontainer:
+    ports:
+      - '${host_port}:${container_port}'
     volumes:
       - '${escaped_workspace_path}:/workspace:cached'
 EOF

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,18 @@ VUE_FRONTEND_NODE_VERSION := 16
 REACT_FRONTEND_NODE_VERSION := 25
 PNPM_VERSION := 10.32.1
 
+# Port the Go server listens on. Defaults to 8080; override with `make run_all
+# PORT=NNNN` or a PORT environment variable so parallel checkouts can use
+# distinct ports. The frontend's browser code uses relative URLs, so only
+# server-side rendering reads NEXT_PUBLIC_API_BASE_URL.
+PORT ?= 8080
+export PORT
+
 # Runs the application (builds Vue.js files, starts Next.js dev server, starts Go server).
 # As of January 2025, upgrading past Node 16 breaks old Vue dependencies.
 run_all:
 	. $(NVM_SCRIPT) && \
-	export NEXT_PUBLIC_API_BASE_URL=http://localhost:8080; \
+	export NEXT_PUBLIC_API_BASE_URL=http://localhost:$(PORT); \
     (cd frontend && nvm use $(VUE_FRONTEND_NODE_VERSION) && npm run dev-build); \
 	(cd frontend-v2 && nvm use $(REACT_FRONTEND_NODE_VERSION) && pnpm dev) &
 	$(MAKE) run

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,7 @@
+{
+  "scripts": {
+    "setup": "ADB_HOST_PORT=$CONDUCTOR_PORT devcontainer up --workspace-folder . && devcontainer exec --workspace-folder . make deps",
+    "run": "ADB_HOST_PORT=$CONDUCTOR_PORT devcontainer up --workspace-folder . && devcontainer exec --workspace-folder . --remote-env PORT=$CONDUCTOR_PORT bash -lc 'fuser -k ${PORT}/tcp 3000/tcp 2>/dev/null; sleep 1; make run_all'"
+  },
+  "runScriptMode": "concurrent"
+}


### PR DESCRIPTION
The `devcontainer` CLI ignores devcontainer.json's `forwardPorts` (a VS Code editor feature), so the Go server wasn't reachable from the host when running via `devcontainer exec`; this publishes the container port at the Docker layer in the generated workspace compose file. The Makefile now parameterizes the server `PORT` (default unchanged at 8080) so each checkout can listen on a distinct port, and `write-workspace-compose.sh` publishes host→container 1:1 when a port is pinned so the logged port matches the reachable host port. A new `conductor.json` adds setup/run scripts that bring up the devcontainer, install deps, and run the app on a per-workspace port. Default local/VS Code behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable port support for running multiple parallel development environments
  * Enhanced devcontainer workspace setup with automatic port mapping
  * Environment variable support for custom port configuration

* **Chores**
  * Updated build system and development configuration for improved parallel development workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dxe/adb/pull/426?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->