### PR TITLE
fix(devcontainer): prevent PORT env from leaking to Next.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,6 @@ PNPM_VERSION := 10.32.1
 # distinct ports. The frontend's browser code uses relative URLs, so only
 # server-side rendering reads NEXT_PUBLIC_API_BASE_URL.
 PORT ?= 8080
-export PORT
 
 # Runs the application (builds Vue.js files, starts Next.js dev server, starts Go server).
 # As of January 2025, upgrading past Node 16 breaks old Vue dependencies.
@@ -34,7 +33,7 @@ run_all:
 	. $(NVM_SCRIPT) && \
 	export NEXT_PUBLIC_API_BASE_URL=http://localhost:$(PORT); \
     (cd frontend && nvm use $(VUE_FRONTEND_NODE_VERSION) && npm run dev-build); \
-	(cd frontend-v2 && nvm use $(REACT_FRONTEND_NODE_VERSION) && pnpm dev) &
+	(cd frontend-v2 && nvm use $(REACT_FRONTEND_NODE_VERSION) && env -u PORT pnpm dev) &
 	$(MAKE) run
 
 # Just start the go program without recompiling the JS.
@@ -43,7 +42,7 @@ run:
 
 	set -a && . server/debug.env && set +a && \
 	cd server/src && \
-	go run main.go
+	PORT=$(PORT) go run main.go
 
 # Builds the frontend Vue JS files.
 js:

--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "setup": "ADB_HOST_PORT=$CONDUCTOR_PORT devcontainer up --workspace-folder . && devcontainer exec --workspace-folder . make deps",
+    "setup": "ADB_HOST_PORT=$CONDUCTOR_PORT devcontainer up --workspace-folder . && devcontainer exec --workspace-folder . make deps && devcontainer exec --workspace-folder . make dev_db && devcontainer exec --workspace-folder . bash -lc 'adb seed activists'",
     "run": "ADB_HOST_PORT=$CONDUCTOR_PORT devcontainer up --workspace-folder . && devcontainer exec --workspace-folder . --remote-env PORT=$CONDUCTOR_PORT bash -lc 'fuser -k ${PORT}/tcp 3000/tcp 2>/dev/null; sleep 1; make run_all'"
   },
   "runScriptMode": "concurrent"


### PR DESCRIPTION
## Summary

- Remove `export PORT` from the Makefile so Next.js doesn't inherit the Go server's port and attempt to bind it, causing an `address already in use` crash on startup
- Use `env -u PORT pnpm dev` to explicitly strip `PORT` from the Next.js process (needed because Conductor injects `PORT` as a shell env var, which persists regardless of the Makefile export)
- Pass `PORT=$(PORT)` explicitly only to `go run main.go`
- Update `conductor.json` setup script to seed the dev database (`make dev_db`) and activist data (`adb seed activists`) after installing deps

## Test plan

- [ ] Run setup in Conductor — devcontainer comes up, deps install, DB is seeded with dev user and activist data
- [ ] Run app in Conductor — Go server binds the workspace port, Next.js starts on 3000, no `address already in use` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)