### PR TITLE
chore(devcontainer): clean up devcontainer resources on workspace archive

### DIFF
--- a/.devcontainer/workspace-archive.sh
+++ b/.devcontainer/workspace-archive.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Runs from conductor.json's scripts.archive, immediately before Conductor
+# archives this workspace. Tears down the per-workspace devcontainer resources
+# that Conductor itself does not clean up: the Docker Compose project (its
+# containers, network, and named volumes) plus the devcontainer image the CLI
+# built for this worktree (~2.9GB each).
+#
+# Best effort: every step is guarded so a missing resource never blocks the
+# archive.
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+compose_file="${script_dir}/compose.workspace.yaml"
+
+# Prefer the project name compose actually used (written by
+# write-workspace-compose.sh at setup time). Fall back to deriving it from the
+# workspace name with the same sanitization as that script.
+project=""
+if [[ -f "${compose_file}" ]]; then
+  project="$(awk '/^name:[[:space:]]*/{print $2; exit}' "${compose_file}")"
+fi
+if [[ -z "${project}" ]]; then
+  ws="$(printf '%s' "${CONDUCTOR_WORKSPACE_NAME:-}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-')"
+  [[ -n "${ws}" ]] && project="dxe-adb-${ws}"
+fi
+
+# Safety: only ever act on our own projects, never an empty name.
+if [[ -z "${project}" || "${project}" != dxe-adb-* ]]; then
+  echo "workspace-archive: could not determine a dxe-adb compose project; skipping cleanup" >&2
+  exit 0
+fi
+
+echo "workspace-archive: tearing down compose project '${project}'" >&2
+docker compose -p "${project}" down --volumes --remove-orphans 2>/dev/null || true
+
+# Remove the devcontainer image the CLI built for this worktree. Its name is
+# vsc-<workspace>-<hash>; the workspace segment is the project name minus the
+# dxe-adb- prefix.
+image_prefix="vsc-${project#dxe-adb-}-"
+images="$(docker image ls --format '{{.Repository}}' 2>/dev/null | grep "^${image_prefix}" || true)"
+if [[ -n "${images}" ]]; then
+  echo "workspace-archive: removing image(s): ${images}" >&2
+  printf '%s\n' "${images}" | xargs -r docker image rm 2>/dev/null || true
+fi
+
+exit 0

--- a/conductor.json
+++ b/conductor.json
@@ -1,7 +1,8 @@
 {
   "scripts": {
     "setup": "ADB_HOST_PORT=$CONDUCTOR_PORT devcontainer up --workspace-folder . && devcontainer exec --workspace-folder . make deps && devcontainer exec --workspace-folder . make dev_db && devcontainer exec --workspace-folder . bash -lc 'adb seed activists'",
-    "run": "ADB_HOST_PORT=$CONDUCTOR_PORT devcontainer up --workspace-folder . && devcontainer exec --workspace-folder . --remote-env PORT=$CONDUCTOR_PORT bash -lc 'fuser -k ${PORT}/tcp 3000/tcp 2>/dev/null; sleep 1; make run_all'"
+    "run": "ADB_HOST_PORT=$CONDUCTOR_PORT devcontainer up --workspace-folder . && devcontainer exec --workspace-folder . --remote-env PORT=$CONDUCTOR_PORT bash -lc 'fuser -k ${PORT}/tcp 3000/tcp 2>/dev/null; sleep 1; make run_all'",
+    "archive": "./.devcontainer/workspace-archive.sh"
   },
   "runScriptMode": "concurrent"
 }


### PR DESCRIPTION
Adds a Conductor `archive` script (`.devcontainer/workspace-archive.sh`) that runs just before a workspace is archived to reclaim the per-workspace devcontainer resources Conductor itself leaves behind. It tears down the Docker Compose project (containers, network, and named volumes) and removes the ~2.9GB `vsc-*` image the devcontainer CLI built for the worktree. Every step is best-effort and guarded so a missing resource never blocks the archive, and it only ever acts on `dxe-adb-*` projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)