### PR TITLE
ci: build images in parallel with tests, promote to latest on green

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,8 +41,6 @@ jobs:
         id: filter
         with:
           filters: |
-            # Everything baked into the server image (Dockerfile): the Go API
-            # and CLI, the shared pkg module, and the legacy Vue frontend.
             server:
               - 'Dockerfile'
               - 'server/**'
@@ -52,20 +50,16 @@ jobs:
               - 'shared/**'
               - 'go.work'
               - 'go.work.sum'
-            # Everything baked into the Next.js image (Dockerfile.frontend-v2).
             frontend:
               - 'Dockerfile.frontend-v2'
               - 'frontend-v2/**'
               - 'shared/**'
-            # The lambdas are their own Go module; pkg/ is pulled in via a
-            # replace directive (GOWORK=off), so both affect the binaries.
             lambdas:
               - 'jobs/**'
               - 'pkg/**'
 
-  # Single shared test + lint run. The image builds run in parallel with this
-  # job, but the promote jobs that flip an image to :latest gate on it via
-  # `needs: test`, so nothing ships unless this passes.
+  # Single shared test + lint run. Image builds run in parallel with this (see
+  # build-server for the rationale); the promote jobs gate on it via `needs: test`.
   test:
     runs-on: ubuntu-latest
     services:
@@ -183,9 +177,8 @@ jobs:
           cache-from: type=gha,scope=server
           cache-to: type=gha,scope=server,mode=max
 
-  # Promote the freshly built server image to :latest once tests pass. This is
-  # a registry-side manifest retag (no layer pull/push), so it finishes in
-  # seconds — the deploy effectively starts the moment tests go green.
+  # Promote the freshly built server image to :latest. Registry-side manifest
+  # retag (no layer pull/push), so it finishes in seconds.
   promote-server:
     needs: [test, build-server, changes]
     if: ${{ github.event_name == 'push' && needs.changes.outputs.server == 'true' }}
@@ -238,7 +231,7 @@ jobs:
           cache-from: type=gha,scope=next
           cache-to: type=gha,scope=next,mode=max
 
-  # Promote the freshly built Next.js image to :latest once tests pass.
+  # Promote the freshly built Next.js image to :latest (see promote-server).
   promote-frontend:
     needs: [test, build-frontend, changes]
     if: ${{ github.event_name == 'push' && needs.changes.outputs.frontend == 'true' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,8 @@ jobs:
               - 'jobs/**'
               - 'pkg/**'
 
-  # Single shared test + lint run. The deploy jobs gate on it via
+  # Single shared test + lint run. The image builds run in parallel with this
+  # job, but the promote jobs that flip an image to :latest gate on it via
   # `needs: test`, so nothing ships unless this passes.
   test:
     runs-on: ubuntu-latest
@@ -149,10 +150,12 @@ jobs:
 
           pnpm exec vitest --run --changed "$since_sha" --passWithNoTests
 
-  # Build and push the server image. Runs only on pushes, only when server
-  # inputs changed, and only after the test job passes.
-  deploy-server:
-    needs: [test, changes]
+  # Build and push the server image under an immutable :<sha> tag. Runs only on
+  # pushes, only when server inputs changed. Deliberately does NOT gate on
+  # `test`, so this slow build overlaps the test run. A :<sha> tag triggers no
+  # deploy on its own; only promote-server (gated on tests) flips it to :latest.
+  build-server:
+    needs: [changes]
     if: ${{ github.event_name == 'push' && needs.changes.outputs.server == 'true' }}
     runs-on: ubuntu-latest
     steps:
@@ -175,16 +178,38 @@ jobs:
         with:
           context: .
           push: true
-          tags: |
-            ${{ steps.login-ecr.outputs.registry }}/dxe/adb:latest
-            ${{ steps.login-ecr.outputs.registry }}/dxe/adb:${{ github.sha }}
+          tags: ${{ steps.login-ecr.outputs.registry }}/dxe/adb:${{ github.sha }}
           # Distinct scope so the two images don't clobber each other's cache.
           cache-from: type=gha,scope=server
           cache-to: type=gha,scope=server,mode=max
 
-  # Build and push the Next.js image.
-  deploy-frontend:
-    needs: [test, changes]
+  # Promote the freshly built server image to :latest once tests pass. This is
+  # a registry-side manifest retag (no layer pull/push), so it finishes in
+  # seconds — the deploy effectively starts the moment tests go green.
+  promote-server:
+    needs: [test, build-server, changes]
+    if: ${{ github.event_name == 'push' && needs.changes.outputs.server == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
+      - name: Retag :${{ github.sha }} as :latest
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ steps.login-ecr.outputs.registry }}/dxe/adb:latest \
+            ${{ steps.login-ecr.outputs.registry }}/dxe/adb:${{ github.sha }}
+
+  # Build and push the Next.js image under an immutable :<sha> tag, in parallel
+  # with `test` (see build-server for the rationale).
+  build-frontend:
+    needs: [changes]
     if: ${{ github.event_name == 'push' && needs.changes.outputs.frontend == 'true' }}
     runs-on: ubuntu-latest
     steps:
@@ -206,11 +231,30 @@ jobs:
           context: .
           file: Dockerfile.frontend-v2
           push: true
-          tags: |
-            ${{ steps.login-ecr.outputs.registry }}/dxe/adb-next:latest
-            ${{ steps.login-ecr.outputs.registry }}/dxe/adb-next:${{ github.sha }}
+          tags: ${{ steps.login-ecr.outputs.registry }}/dxe/adb-next:${{ github.sha }}
           cache-from: type=gha,scope=next
           cache-to: type=gha,scope=next,mode=max
+
+  # Promote the freshly built Next.js image to :latest once tests pass.
+  promote-frontend:
+    needs: [test, build-frontend, changes]
+    if: ${{ github.event_name == 'push' && needs.changes.outputs.frontend == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
+      - name: Retag :${{ github.sha }} as :latest
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ steps.login-ecr.outputs.registry }}/dxe/adb-next:latest \
+            ${{ steps.login-ecr.outputs.registry }}/dxe/adb-next:${{ github.sha }}
 
   # Build and deploy the jobs lambdas via SAM. us-west-2 matches jobs/Makefile.
   deploy-lambdas:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -201,10 +201,13 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
       - name: Retag :${{ github.sha }} as :latest
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          SHA: ${{ github.sha }}
         run: |
           docker buildx imagetools create \
-            --tag ${{ steps.login-ecr.outputs.registry }}/dxe/adb:latest \
-            ${{ steps.login-ecr.outputs.registry }}/dxe/adb:${{ github.sha }}
+            --tag "$REGISTRY/dxe/adb:latest" \
+            "$REGISTRY/dxe/adb:$SHA"
 
   # Build and push the Next.js image under an immutable :<sha> tag, in parallel
   # with `test` (see build-server for the rationale).
@@ -251,10 +254,13 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
       - name: Retag :${{ github.sha }} as :latest
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          SHA: ${{ github.sha }}
         run: |
           docker buildx imagetools create \
-            --tag ${{ steps.login-ecr.outputs.registry }}/dxe/adb-next:latest \
-            ${{ steps.login-ecr.outputs.registry }}/dxe/adb-next:${{ github.sha }}
+            --tag "$REGISTRY/dxe/adb-next:latest" \
+            "$REGISTRY/dxe/adb-next:$SHA"
 
   # Build and deploy the jobs lambdas via SAM. us-west-2 matches jobs/Makefile.
   deploy-lambdas:


### PR DESCRIPTION
Split the deploy jobs into build (push :sha, runs alongside test) and promote (retag :sha to :latest, gated on test). Lets the slow image build overlap the test run so deploy starts as soon as tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized container deployment pipeline by decoupling image build and promotion phases. Container images are now created with immutable tags and promoted to latest only after tests pass, improving deployment efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->