### PR TITLE
fix(devcontainer): make worktree script not break windows users

### DIFF
--- a/.devcontainer/write-workspace-compose.sh
+++ b/.devcontainer/write-workspace-compose.sh
@@ -7,15 +7,41 @@ set -euo pipefail
 # at devcontainer startup time so the generated file reflects the actual paths
 # on the host machine (which vary per developer and per worktree).
 
-# The workspace path is passed in as the first argument.
-workspace_path="${1:?workspace path is required}"
+# The workspace path is passed in as the first argument. On macOS/Linux hosts
+# it is already a POSIX path. On Windows hosts VS Code/Cursor pass a native path
+# like c:\Users\foo\repo, which we support only in a reduced, single-checkout
+# mode (see the Windows branch below).
+raw_workspace_path="${1:?workspace path is required}"
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 output_file="${script_dir}/compose.workspace.yaml"
+
+# Detect a Windows-style path (a drive-letter prefix such as C:\ or C:/).
+#
+# Git worktree support requires bind-mounting host paths so the same absolute
+# path resolves both inside and outside the container. That does not work
+# across the Windows/WSL/Docker-Desktop path-translation boundary without
+# juggling three path formats (native, WSL /mnt/c, and Docker c:/...). Rather
+# than carry that complexity, Windows gets a reduced setup: the workspace is
+# mounted at /workspace and nothing else. Ordinary (non-worktree) checkouts
+# work fully; git worktrees are not supported on Windows.
+normalized_path="${raw_workspace_path//\\//}"
+if [[ "${normalized_path}" =~ ^[A-Za-z]: ]]; then
+  is_windows=1
+  # Docker Desktop bind mounts want a lowercase drive letter with forward
+  # slashes, e.g. c:/Users/foo/repo.
+  drive="$(printf '%s' "${normalized_path:0:1}" | tr '[:upper:]' '[:lower:]')"
+  docker_workspace_path="${drive}:${normalized_path:2}"
+  workspace_name="$(basename "${normalized_path}")"
+else
+  is_windows=0
+  workspace_path="${raw_workspace_path}"
+  docker_workspace_path="${workspace_path}"
+  workspace_name="$(basename "${workspace_path}")"
+fi
 
 # Derive a DNS-safe project name from the folder name so each worktree gets its
 # own isolated Compose project. Without this, VS Code would reattach to whatever
 # container happened to share the same default project name.
-workspace_name="$(basename "${workspace_path}")"
 sanitized_workspace_name="$(printf '%s' "${workspace_name}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-')"
 project_name="dxe-adb-${sanitized_workspace_name}"
 
@@ -39,16 +65,8 @@ else
 fi
 echo "write-workspace-compose: publishing container port ${container_port} on host port ${host_port}" >&2
 
-# Ask git where it stores its data. For a normal repo these two paths are the
-# same. For a git worktree they differ: git-dir points to a worktree-specific
-# stub, while git-common-dir points to the main repo's .git where objects and
-# refs actually live.
-abs_git_dir="$(git -C "${workspace_path}" rev-parse --path-format=absolute --git-dir)"
-abs_git_common_dir="$(git -C "${workspace_path}" rev-parse --path-format=absolute --git-common-dir)"
-
 # Escape single quotes so paths with apostrophes don't break the YAML output.
-escaped_workspace_path=${workspace_path//\'/\'\'}
-escaped_abs_git_common_dir=${abs_git_common_dir//\'/\'\'}
+escaped_workspace_path=${docker_workspace_path//\'/\'\'}
 
 # Write the base YAML: name the project and mount the workspace at /workspace.
 cat >"${output_file}" <<EOF
@@ -61,8 +79,31 @@ services:
     ports:
       - '${host_port}:${container_port}'
     volumes:
-      - '${escaped_workspace_path}:/workspace:cached'
+      # Long syntax (explicit source/target) so a Windows drive-letter path like
+      # c:/Users/foo/repo is not mis-parsed by Compose's colon-delimited short
+      # form, which is ambiguous when the source itself contains a colon.
+      - type: bind
+        source: '${escaped_workspace_path}'
+        target: /workspace
+        consistency: cached
 EOF
+
+# Windows: stop here. The reduced setup above is all we support; git worktrees
+# need the extra host-path mounts below, which we deliberately skip.
+if [[ "${is_windows}" -eq 1 ]]; then
+  echo "write-workspace-compose: Windows host detected; git worktrees are not supported (workspace mounted at /workspace only)" >&2
+  exit 0
+fi
+
+# Ask git where it stores its data. For a normal repo these two paths are the
+# same. For a git worktree they differ: git-dir points to a worktree-specific
+# stub, while git-common-dir points to the main repo's .git where objects and
+# refs actually live.
+abs_git_dir="$(git -C "${workspace_path}" rev-parse --path-format=absolute --git-dir)"
+abs_git_common_dir="$(git -C "${workspace_path}" rev-parse --path-format=absolute --git-common-dir)"
+
+# Escape single quotes so paths with apostrophes don't break the YAML output.
+escaped_abs_git_common_dir=${abs_git_common_dir//\'/\'\'}
 
 # Extra mounts needed only for git worktrees. A worktree's .git is a pointer
 # file, not a full directory, so git commands inside the container must also be

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,7 +4,8 @@
 # Keep in sync with "make fmt".
 
 gofiles=$(cd server && gofmt -l .)
-webfiles=$(pnpx prettier -l --cache --cache-strategy metadata .)
+# Pin to same version as root package.json to match `make fmt`.
+webfiles=$(pnpx prettier@3.7.3 -l --cache --cache-strategy metadata .)
 [ -z "$gofiles" -a -z "$webfiles" ] && exit 0
 
 echo >&2 "Misformatted files:"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "dxe-adb",
   "private": true,
+  "_comments": {
+    "prettier": "Please keep version in sync with .githooks/pre-commit"
+  },
   "devDependencies": {
     "prettier": "~3.7.3"
   },


### PR DESCRIPTION
but don't actually support worktrees on Windows yet since Windows users tend to be less involved and probably won't need it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace setup for Windows paths, making container-based development more reliable on Windows hosts.
  * Updated path handling to better support workspace mounting and naming across different path formats.
  * Adjusted worktree handling so Windows setups skip unsupported extra mount logic, avoiding setup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->