### PR TITLE
Port external events admin page to React

### DIFF
--- a/frontend-v2/src/app/(authed)/external-events/cancel-event-dialog.tsx
+++ b/frontend-v2/src/app/(authed)/external-events/cancel-event-dialog.tsx
@@ -54,7 +54,7 @@ export function CancelEventDialog({
         </DialogHeader>
         <p className="text-sm">
           Are you sure you want to cancel &ldquo;{eventName}&rdquo;? It will no
-          longer be shown to activists.
+          longer be displayed on the public events page.
         </p>
         <DialogFooter>
           <Button

--- a/frontend-v2/src/app/(authed)/external-events/cancel-event-dialog.tsx
+++ b/frontend-v2/src/app/(authed)/external-events/cancel-event-dialog.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import toast from 'react-hot-toast'
+import { API_PATH, apiClient } from '@/lib/api'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+type Props = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  eventId: string
+  eventName: string
+}
+
+export function CancelEventDialog({
+  open,
+  onOpenChange,
+  eventId,
+  eventName,
+}: Props) {
+  const queryClient = useQueryClient()
+
+  const mutation = useMutation({
+    mutationFn: () => apiClient.cancelExternalEvent(eventId),
+    onSuccess: () => {
+      toast.success('Successfully cancelled event.')
+      queryClient.invalidateQueries({
+        queryKey: [API_PATH.EXTERNAL_EVENTS_LIST],
+      })
+      onOpenChange(false)
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || 'Failed to cancel event')
+    },
+  })
+
+  const handleOpenChange = (next: boolean) => {
+    if (mutation.isPending) return
+    onOpenChange(next)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Cancel event</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm">
+          Are you sure you want to cancel &ldquo;{eventName}&rdquo;? It will no
+          longer be shown to activists.
+        </p>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={mutation.isPending}
+          >
+            Keep event
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={() => mutation.mutate()}
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? 'Cancelling...' : 'Cancel event'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend-v2/src/app/(authed)/external-events/external-events-page.tsx
+++ b/frontend-v2/src/app/(authed)/external-events/external-events-page.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { Loader2 } from 'lucide-react'
+import { API_PATH, apiClient } from '@/lib/api'
+import { ExternalEventsTable } from './external-events-table'
+
+export default function ExternalEventsPage() {
+  const {
+    data: events,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: [API_PATH.EXTERNAL_EVENTS_LIST],
+    queryFn: ({ signal }) => apiClient.getExternalEvents(signal),
+  })
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1">
+        <h1 className="text-2xl font-semibold">Facebook Events</h1>
+        <p className="text-muted-foreground text-sm">
+          Feature or cancel upcoming Facebook/Eventbrite events shown to
+          activists.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading events...
+        </div>
+      ) : isError || !events ? (
+        <div className="text-sm text-destructive">Failed to load events</div>
+      ) : (
+        <ExternalEventsTable events={events} />
+      )}
+    </div>
+  )
+}

--- a/frontend-v2/src/app/(authed)/external-events/external-events-page.tsx
+++ b/frontend-v2/src/app/(authed)/external-events/external-events-page.tsx
@@ -6,11 +6,7 @@ import { API_PATH, apiClient } from '@/lib/api'
 import { ExternalEventsTable } from './external-events-table'
 
 export default function ExternalEventsPage() {
-  const {
-    data: events,
-    isLoading,
-    isError,
-  } = useQuery({
+  const { data: events, isLoading } = useQuery({
     queryKey: [API_PATH.EXTERNAL_EVENTS_LIST],
     queryFn: ({ signal }) => apiClient.getExternalEvents(signal),
   })
@@ -20,8 +16,8 @@ export default function ExternalEventsPage() {
       <div className="flex flex-col gap-1">
         <h1 className="text-2xl font-semibold">Facebook Events</h1>
         <p className="text-muted-foreground text-sm">
-          Feature or cancel upcoming Facebook/Eventbrite events shown to
-          activists.
+          Feature or cancel upcoming Facebook/Eventbrite events displayed on the
+          public events page.
         </p>
       </div>
 
@@ -30,10 +26,10 @@ export default function ExternalEventsPage() {
           <Loader2 className="h-4 w-4 animate-spin" />
           Loading events...
         </div>
-      ) : isError || !events ? (
-        <div className="text-sm text-destructive">Failed to load events</div>
-      ) : (
+      ) : events ? (
         <ExternalEventsTable events={events} />
+      ) : (
+        <div className="text-sm text-destructive">Failed to load events</div>
       )}
     </div>
   )

--- a/frontend-v2/src/app/(authed)/external-events/external-events-table.tsx
+++ b/frontend-v2/src/app/(authed)/external-events/external-events-table.tsx
@@ -1,0 +1,225 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  SortingState,
+  useReactTable,
+} from '@tanstack/react-table'
+import { format } from 'date-fns'
+import { Star, Trash2 } from 'lucide-react'
+import toast from 'react-hot-toast'
+import { API_PATH, apiClient, ExternalEvent } from '@/lib/api'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Button } from '@/components/ui/button'
+import { SortIndicator } from '@/components/ui/sort-indicator'
+import { CancelEventDialog } from './cancel-event-dialog'
+
+export function ExternalEventsTable({ events }: { events: ExternalEvent[] }) {
+  const queryClient = useQueryClient()
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: 'StartTime', desc: false },
+  ])
+  const [eventToCancel, setEventToCancel] = useState<ExternalEvent | null>(null)
+
+  const featureMutation = useMutation({
+    mutationFn: ({ id, featured }: { id: string; featured: boolean }) =>
+      apiClient.featureExternalEvent(id, featured),
+    onSuccess: (_data, { id, featured }) => {
+      toast.success(
+        featured
+          ? 'Successfully featured event.'
+          : 'Successfully unfeatured event.',
+      )
+      queryClient.setQueryData(
+        [API_PATH.EXTERNAL_EVENTS_LIST],
+        (old: ExternalEvent[] | undefined) =>
+          old?.map((event) =>
+            event.ID === id ? { ...event, Featured: featured } : event,
+          ),
+      )
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || 'Failed to update event')
+    },
+  })
+
+  const columns = useMemo<ColumnDef<ExternalEvent>[]>(
+    () => [
+      {
+        id: 'StartTime',
+        header: ({ column }) => (
+          <button
+            type="button"
+            onClick={column.getToggleSortingHandler()}
+            className="flex items-center gap-1"
+          >
+            <span>Date</span>
+            <SortIndicator sorted={column.getIsSorted()} />
+          </button>
+        ),
+        accessorKey: 'StartTime',
+        cell: ({ getValue }) =>
+          format(new Date(getValue<string>()), 'yyyy-MM-dd'),
+      },
+      {
+        id: 'Name',
+        header: ({ column }) => (
+          <button
+            type="button"
+            onClick={column.getToggleSortingHandler()}
+            className="flex items-center gap-1"
+          >
+            <span>Name</span>
+            <SortIndicator sorted={column.getIsSorted()} />
+          </button>
+        ),
+        accessorKey: 'Name',
+        cell: ({ row }) => (
+          <a
+            href={`https://facebook.com/${row.original.ID}`}
+            target="_blank"
+            rel="noreferrer"
+            className="text-primary underline-offset-4 hover:underline"
+          >
+            {row.original.Name}
+          </a>
+        ),
+      },
+      {
+        id: 'featured',
+        header: '',
+        cell: ({ row }) => {
+          const event = row.original
+          const isPending =
+            featureMutation.isPending &&
+            featureMutation.variables?.id === event.ID
+          return (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                featureMutation.mutate({
+                  id: event.ID,
+                  featured: !event.Featured,
+                })
+              }
+              disabled={isPending}
+              className={
+                event.Featured
+                  ? 'text-amber-600 hover:text-amber-600'
+                  : undefined
+              }
+            >
+              <Star className={event.Featured ? 'fill-current' : undefined} />
+              {event.Featured ? 'Featured' : 'Feature'}
+            </Button>
+          )
+        },
+      },
+      {
+        id: 'actions',
+        header: '',
+        cell: ({ row }) => (
+          <Button
+            type="button"
+            variant="destructive"
+            size="sm"
+            onClick={() => setEventToCancel(row.original)}
+          >
+            <Trash2 />
+            Delete
+          </Button>
+        ),
+      },
+    ],
+    [featureMutation],
+  )
+
+  // eslint-disable-next-line react-hooks/incompatible-library -- Remove once TanStack Table supports React Compiler.
+  const table = useReactTable({
+    data: events,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    onSortingChange: setSorting,
+    state: {
+      sorting,
+    },
+  })
+
+  const rows = table.getRowModel().rows
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id} className="whitespace-nowrap">
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {rows.length ? (
+              rows.map((row) => (
+                <TableRow key={row.id}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="text-center py-6"
+                >
+                  No upcoming events found.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {eventToCancel && (
+        <CancelEventDialog
+          open
+          onOpenChange={(open) => {
+            if (!open) setEventToCancel(null)
+          }}
+          eventId={eventToCancel.ID}
+          eventName={eventToCancel.Name}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend-v2/src/app/(authed)/external-events/loading.tsx
+++ b/frontend-v2/src/app/(authed)/external-events/loading.tsx
@@ -1,0 +1,11 @@
+import { ContentWrapper } from '@/app/content-wrapper'
+import { Loading } from '@/app/loading'
+
+export default function ExternalEventsLoading() {
+  return (
+    <ContentWrapper size="xl" className="gap-6">
+      <h1 className="text-2xl font-semibold">Facebook Events</h1>
+      <Loading inline />
+    </ContentWrapper>
+  )
+}

--- a/frontend-v2/src/app/(authed)/external-events/page.tsx
+++ b/frontend-v2/src/app/(authed)/external-events/page.tsx
@@ -1,0 +1,38 @@
+import { forbidden } from 'next/navigation'
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from '@tanstack/react-query'
+import { ContentWrapper } from '@/app/content-wrapper'
+import { getCachedSession } from '@/app/session'
+import { API_PATH, ApiClient } from '@/lib/api'
+import { getCookies } from '@/lib/auth'
+import ExternalEventsPage from './external-events-page'
+
+export default async function ExternalEventsListPage() {
+  const session = await getCachedSession()
+  if (!session.user?.Roles.includes('admin')) {
+    forbidden()
+  }
+
+  const apiClient = new ApiClient(await getCookies())
+  const queryClient = new QueryClient()
+
+  // Intentionally use prefetchQuery here: this endpoint isn't itself
+  // admin-gated (the legacy Vue page calls it unauthenticated), so there's no
+  // 403/404 to redirect on and a failed prefetch can just fall through to the
+  // client-side useQuery below.
+  await queryClient.prefetchQuery({
+    queryKey: [API_PATH.EXTERNAL_EVENTS_LIST],
+    queryFn: ({ signal }) => apiClient.getExternalEvents(signal),
+  })
+
+  return (
+    <ContentWrapper size="xl" className="gap-6">
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <ExternalEventsPage />
+      </HydrationBoundary>
+    </ContentWrapper>
+  )
+}

--- a/frontend-v2/src/app/(authed)/external-events/page.tsx
+++ b/frontend-v2/src/app/(authed)/external-events/page.tsx
@@ -19,10 +19,8 @@ export default async function ExternalEventsListPage() {
   const apiClient = new ApiClient(await getCookies())
   const queryClient = new QueryClient()
 
-  // Intentionally use prefetchQuery here: this endpoint isn't itself
-  // admin-gated (the legacy Vue page calls it unauthenticated), so there's no
-  // 403/404 to redirect on and a failed prefetch can just fall through to the
-  // client-side useQuery below.
+  // prefetchQuery, not fetchQuery + redirectForHttpError: the endpoint isn't
+  // admin-gated, so a failed prefetch just falls through to the client useQuery.
   await queryClient.prefetchQuery({
     queryKey: [API_PATH.EXTERNAL_EVENTS_LIST],
     queryFn: ({ signal }) => apiClient.getExternalEvents(signal),

--- a/frontend-v2/src/lib/api.ts
+++ b/frontend-v2/src/lib/api.ts
@@ -296,14 +296,10 @@ export interface EventListParams {
   event_type: EventType
 }
 
-// The SF Bay Facebook page ID. Listing external events for this page returns
-// merged/deduped events from all SF Bay Area Facebook pages (see
-// ListFBEventsHandler in server/src/main.go).
+// Listing events for this page ID returns merged events from all SF Bay pages.
 const SF_BAY_FACEBOOK_PAGE_ID = '1377014279263790'
 
-// Go's ExternalEvent struct (server/src/model/external_events.go) has no
-// `json` tags, so field names are serialized as-is (PascalCase). Only the
-// fields the admin external-events page needs are declared here.
+// Go's ExternalEvent struct has no `json` tags, so fields serialize as PascalCase.
 const ExternalEventSchema = z.object({
   ID: z.string(),
   Name: z.string(),
@@ -777,17 +773,13 @@ export class ApiClient {
     }
   }
 
-  // Lists upcoming Facebook/Eventbrite events for the SF Bay page, matching
-  // the legacy admin FacebookEvents.vue page's hardcoded page ID and
-  // "today onward" start_time window. The date is derived from UTC explicitly
-  // so the SSR prefetch (server TZ) and the client refetch (browser TZ) always
-  // agree on the "today" boundary.
   getExternalEvents = async (signal?: AbortSignal) => {
     try {
-      const startTime = `${new Date().toISOString().slice(0, 10)}T00:00:00Z`
+      // UTC date so SSR prefetch and client refetch agree on the "today" boundary.
+      const startOfTodayUtc = `${new Date().toISOString().slice(0, 10)}T00:00:00Z`
       const resp = await this.client
         .get(`${API_PATH.EXTERNAL_EVENTS_LIST}/${SF_BAY_FACEBOOK_PAGE_ID}`, {
-          searchParams: { start_time: startTime },
+          searchParams: { start_time: startOfTodayUtc },
           signal,
         })
         .json()

--- a/frontend-v2/src/lib/api.ts
+++ b/frontend-v2/src/lib/api.ts
@@ -1,5 +1,6 @@
 import ky, { HTTPError, KyInstance } from 'ky'
 import { z } from 'zod'
+import { format } from 'date-fns'
 import {
   ActivistJSON,
   ActivistPatchInput,
@@ -35,6 +36,9 @@ export const API_PATH = {
   EVENT_DELETE: 'event/delete',
   COACHING_SAVE: 'connection/save',
   ADMIN_SEND_TEST_EMAIL: 'api/admin/send-test-email',
+  EXTERNAL_EVENTS_LIST: 'external_events',
+  EXTERNAL_EVENT_FEATURE: 'admin/external_events/feature',
+  EXTERNAL_EVENT_CANCEL: 'admin/external_events/cancel',
 }
 
 export const StaticResourcesHashResp = z.object({
@@ -292,6 +296,29 @@ export interface EventListParams {
   event_date_end: string
   event_type: EventType
 }
+
+// The SF Bay Facebook page ID. Listing external events for this page returns
+// merged/deduped events from all SF Bay Area Facebook pages (see
+// ListFBEventsHandler in server/src/main.go).
+const SF_BAY_FACEBOOK_PAGE_ID = '1377014279263790'
+
+// Go's ExternalEvent struct (server/src/model/external_events.go) has no
+// `json` tags, so field names are serialized as-is (PascalCase). Only the
+// fields the admin external-events page needs are declared here.
+const ExternalEventSchema = z.object({
+  ID: z.string(),
+  Name: z.string(),
+  StartTime: z.string(),
+  Featured: z.boolean(),
+})
+export type ExternalEvent = z.infer<typeof ExternalEventSchema>
+
+const ExternalEventsListResp = z.object({
+  events: z
+    .array(ExternalEventSchema)
+    .nullable()
+    .transform((v) => v ?? []),
+})
 
 const SuccessResp = z.object({
   status: z.literal('success'),
@@ -741,6 +768,56 @@ export class ApiClient {
       const resp = await this.client
         .post(API_PATH.EVENT_DELETE, {
           body,
+          headers: { 'X-CSRF-Token': csrfToken },
+        })
+        .json()
+      this.throwIfApiError(resp)
+      return SuccessResp.parse(resp)
+    } catch (err) {
+      return this.handleKyError(err)
+    }
+  }
+
+  // Lists upcoming Facebook/Eventbrite events for the SF Bay page, matching
+  // the legacy admin FacebookEvents.vue page's hardcoded page ID and
+  // "today onward" start_time window.
+  getExternalEvents = async (signal?: AbortSignal) => {
+    try {
+      const startTime = `${format(new Date(), 'yyyy-MM-dd')}T00:00:00Z`
+      const resp = await this.client
+        .get(`${API_PATH.EXTERNAL_EVENTS_LIST}/${SF_BAY_FACEBOOK_PAGE_ID}`, {
+          searchParams: { start_time: startTime },
+          signal,
+        })
+        .json()
+      return ExternalEventsListResp.parse(resp).events
+    } catch (err) {
+      return this.handleKyError(err)
+    }
+  }
+
+  featureExternalEvent = async (id: string, featured: boolean) => {
+    try {
+      const csrfToken = await this.getCsrfToken()
+      const resp = await this.client
+        .post(API_PATH.EXTERNAL_EVENT_FEATURE, {
+          json: { id, featured },
+          headers: { 'X-CSRF-Token': csrfToken },
+        })
+        .json()
+      this.throwIfApiError(resp)
+      return SuccessResp.parse(resp)
+    } catch (err) {
+      return this.handleKyError(err)
+    }
+  }
+
+  cancelExternalEvent = async (id: string) => {
+    try {
+      const csrfToken = await this.getCsrfToken()
+      const resp = await this.client
+        .post(API_PATH.EXTERNAL_EVENT_CANCEL, {
+          json: { id },
           headers: { 'X-CSRF-Token': csrfToken },
         })
         .json()

--- a/frontend-v2/src/lib/api.ts
+++ b/frontend-v2/src/lib/api.ts
@@ -1,6 +1,5 @@
 import ky, { HTTPError, KyInstance } from 'ky'
 import { z } from 'zod'
-import { format } from 'date-fns'
 import {
   ActivistJSON,
   ActivistPatchInput,
@@ -780,10 +779,12 @@ export class ApiClient {
 
   // Lists upcoming Facebook/Eventbrite events for the SF Bay page, matching
   // the legacy admin FacebookEvents.vue page's hardcoded page ID and
-  // "today onward" start_time window.
+  // "today onward" start_time window. The date is derived from UTC explicitly
+  // so the SSR prefetch (server TZ) and the client refetch (browser TZ) always
+  // agree on the "today" boundary.
   getExternalEvents = async (signal?: AbortSignal) => {
     try {
-      const startTime = `${format(new Date(), 'yyyy-MM-dd')}T00:00:00Z`
+      const startTime = `${new Date().toISOString().slice(0, 10)}T00:00:00Z`
       const resp = await this.client
         .get(`${API_PATH.EXTERNAL_EVENTS_LIST}/${SF_BAY_FACEBOOK_PAGE_ID}`, {
           searchParams: { start_time: startTime },

--- a/frontend-v2/src/lib/api.ts
+++ b/frontend-v2/src/lib/api.ts
@@ -296,10 +296,10 @@ export interface EventListParams {
   event_type: EventType
 }
 
-// Listing events for this page ID returns merged events from all SF Bay pages.
+// The external events admin page is only used for SF Bay (parity with the
+// legacy Vue page), so the page ID is hardcoded.
 const SF_BAY_FACEBOOK_PAGE_ID = '1377014279263790'
 
-// Go's ExternalEvent struct has no `json` tags, so fields serialize as PascalCase.
 const ExternalEventSchema = z.object({
   ID: z.string(),
   Name: z.string(),

--- a/shared/nav.json
+++ b/shared/nav.json
@@ -161,8 +161,8 @@
         },
         {
           "label": "Facebook Events",
-          "href": "/admin/external_events",
-          "page": "FacebookEvents",
+          "href": "/v2/external-events",
+          "page": "FacebookEvents_beta",
           "roleRequired": ["admin"]
         },
         {
@@ -273,6 +273,13 @@
           "page": "NewActivistsPendingWorkshopList",
           "roleRequired": ["organizer"],
           "visibleForNonSFBay": false
+        },
+        {
+          "label": "Facebook Events",
+          "href": "/admin/external_events",
+          "page": "FacebookEvents",
+          "roleRequired": ["admin"],
+          "visibleForNonSFBay": true
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Ports the admin-only "Facebook Events" moderation page from Vue (`frontend/FacebookEvents.vue`, route `/admin/external_events`) to Next.js at `frontend-v2/src/app/(authed)/external-events/page.tsx`, served at `/v2/external-events`.
- Lists upcoming Facebook/Eventbrite events for the SF Bay page (same hardcoded page ID and "today onward" window as the legacy page), with actions to feature/unfeature an event or cancel (soft-delete) it.
- No backend changes; the legacy Vue page and its route are untouched and remain available under "Legacy" in the nav.

## Endpoints used (all pre-existing, no Go changes)
- `GET /external_events/{page_id}?start_time=...` — lists events (same endpoint the Vue page calls; not itself admin-gated at the API level, but the new route/nav entry are admin-only).
- `POST /admin/external_events/feature` — `{ id, featured }`, toggles the featured flag.
- `POST /admin/external_events/cancel` — `{ id }`, soft-deletes (sets `is_canceled`) an event.

Added typed `ApiClient` methods (`getExternalEvents`, `featureExternalEvent`, `cancelExternalEvent`) and `API_PATH` entries in `frontend-v2/src/lib/api.ts`, following the file's existing zod-schema + `handleKyError`/`throwIfApiError` conventions. Note the Go `ExternalEvent` struct has no `json` tags, so response fields are PascalCase (`ID`, `Name`, `StartTime`, `Featured`) — `ID` is a string (Facebook IDs), not a number.

## Nav changes (`shared/nav.json`)
- Admin dropdown's "Facebook Events" item now points to `/v2/external-events` with `page: "FacebookEvents_beta"` (still `roleRequired: ["admin"]`).
- Appended a "Facebook Events" entry to the end of the "Legacy" dropdown pointing at the old `/admin/external_events` route, so the Vue page stays reachable.

## Feature parity / intentional differences
- Full parity: list events, format start date, link event name to `facebook.com/{id}`, toggle featured (with success/error toast instead of the Vue `flashMessage`), cancel event with confirmation.
- Added a confirmation dialog before cancelling an event (the Vue page cancelled immediately on click with no confirmation) — matches this app's existing destructive-action pattern (see `hide-activist-dialog.tsx`).
- Admin gating mirrors `frontend-v2/src/app/(authed)/config/page.tsx`: server component checks `session.user.Roles.includes('admin')` and calls `forbidden()` otherwise.

## Test plan
- [x] `pnpm exec tsc --noEmit` — no new errors (repo has 2 pre-existing/environmental errors unrelated to this change: `tsconfig.json` `baseUrl` deprecation warning under the installed TypeScript version, and a missing `$public/logo.png` module type in `nav.tsx`; both reproduce identically on `main` before this change).
- [x] `pnpm lint` — clean.
- [x] `pnpm build` — succeeds, `/external-events` route builds.
- [ ] Manually verify in a running dev environment: load `/v2/external-events` as an admin, feature/unfeature and cancel an event, and confirm a non-admin is forbidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)