### PR TITLE
fix(frontend-v2): re-fetch CSRF on expiration

### DIFF
--- a/frontend-v2/next.config.ts
+++ b/frontend-v2/next.config.ts
@@ -17,6 +17,7 @@ const nextConfig: NextConfig = {
     // Turbopack may detect the workspace's pnpm-lock.yaml and thus decide to use the workspace as the root anyway.
     root: path.resolve(__dirname, '..'),
   },
+  allowedDevOrigins: ['[::1]'],
 }
 
 export default nextConfig

--- a/frontend-v2/src/lib/api.test.ts
+++ b/frontend-v2/src/lib/api.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ApiClient uses a "/" prefix in the browser, producing root-relative request
+// URLs that a real browser resolves against the document. Under jsdom the
+// global Request comes from node's undici, which rejects relative URLs, so
+// shim it to resolve them against a base origin for the duration of the test.
+const RealRequest = globalThis.Request
+class BaseResolvingRequest extends RealRequest {
+  constructor(input: RequestInfo | URL, init?: RequestInit) {
+    if (typeof input === 'string' && input.startsWith('/')) {
+      input = `http://localhost${input}`
+    }
+    super(input, init)
+  }
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+type FetchHandler = (req: Request) => Response | Promise<Response>
+
+function stubFetch(handler: FetchHandler) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init)
+      return handler(req)
+    }),
+  )
+}
+
+async function loadApi() {
+  vi.resetModules()
+  return import('./api')
+}
+
+beforeEach(() => {
+  vi.stubGlobal('Request', BaseResolvingRequest)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+// These tests exercise the CSRF invalidate-and-retry path in ApiClient. The
+// token is cached at module scope, so each test loads a fresh copy of the
+// module (vi.resetModules) to start from an empty cache, and drives the real ky
+// client by stubbing globalThis.fetch.
+describe('ApiClient CSRF handling', () => {
+  it('refetches the token and retries once when a stale token is rejected', async () => {
+    const tokens = ['stale-token', 'fresh-token']
+    let tokenIdx = 0
+    const sentTokens: (string | null)[] = []
+    let postCalls = 0
+
+    stubFetch(async (req) => {
+      const { pathname } = new URL(req.url)
+      if (pathname.endsWith('/api/csrf-token')) {
+        return jsonResponse({
+          status: 'success',
+          csrfToken: tokens[tokenIdx++],
+        })
+      }
+      if (pathname.endsWith('/api/admin/send-test-email')) {
+        postCalls++
+        sentTokens.push(req.headers.get('X-CSRF-Token'))
+        // First attempt carries the stale token; the server rejects it the way
+        // gorilla/csrf does once the underlying cookie has rotated.
+        if (postCalls === 1) {
+          return new Response('Forbidden - CSRF token invalid', { status: 403 })
+        }
+        return jsonResponse({ status: 'success' })
+      }
+      throw new Error(`unexpected request: ${req.url}`)
+    })
+
+    const { apiClient } = await loadApi()
+    const result = await apiClient.sendTestEmail('test@example.com')
+
+    expect(result).toEqual({ status: 'success' })
+    // The mutation was attempted twice, with the refreshed token on the retry.
+    expect(postCalls).toBe(2)
+    expect(sentTokens).toEqual(['stale-token', 'fresh-token'])
+  })
+
+  it('does not retry a plain authorization 403', async () => {
+    let postCalls = 0
+
+    stubFetch(async (req) => {
+      const { pathname } = new URL(req.url)
+      if (pathname.endsWith('/api/csrf-token')) {
+        return jsonResponse({ status: 'success', csrfToken: 'token' })
+      }
+      if (pathname.endsWith('/api/admin/send-test-email')) {
+        postCalls++
+        // Authorization denial: bare "Forbidden", no CSRF failure reason.
+        return new Response('Forbidden', { status: 403 })
+      }
+      throw new Error(`unexpected request: ${req.url}`)
+    })
+
+    const { apiClient } = await loadApi()
+    await expect(apiClient.sendTestEmail('test@example.com')).rejects.toThrow()
+    // No refetch/retry: the request was attempted exactly once.
+    expect(postCalls).toBe(1)
+  })
+})

--- a/frontend-v2/src/lib/api.test.ts
+++ b/frontend-v2/src/lib/api.test.ts
@@ -108,4 +108,19 @@ describe('ApiClient CSRF handling', () => {
     // No refetch/retry: the request was attempted exactly once.
     expect(postCalls).toBe(1)
   })
+
+  it('surfaces the server error message from a JSON error response', async () => {
+    stubFetch(async () =>
+      jsonResponse({ status: 'error', message: 'boom' }, 400),
+    )
+
+    const { apiClient, HTTPStatusError } = await loadApi()
+    // ky drains the response body onto err.data; handleKyError must read the
+    // message from there rather than re-reading the (consumed) response.
+    await expect(apiClient.getUsers()).rejects.toMatchObject({
+      constructor: HTTPStatusError,
+      status: 400,
+      message: 'boom',
+    })
+  })
 })

--- a/frontend-v2/src/lib/api.ts
+++ b/frontend-v2/src/lib/api.ts
@@ -358,8 +358,7 @@ export class HTTPStatusError extends Error {
   }
 }
 
-// Module-level cache for the CSRF token. Safe to cache indefinitely because
-// the _gorilla_csrf cookie (and thus the token value) doesn't rotate mid-session.
+// Module-level cache for the CSRF token, shared across ApiClient instances.
 let _csrfTokenCache: string | undefined
 let _csrfTokenPending: Promise<string | undefined> | null = null
 
@@ -380,6 +379,25 @@ async function getCsrfToken(client: ApiClient): Promise<string | undefined> {
     )
   }
   return _csrfTokenPending
+}
+
+// Drops the cached token so the next getCsrfToken() refetches from the server.
+function invalidateCsrfToken() {
+  _csrfTokenCache = undefined
+  _csrfTokenPending = null
+}
+
+// Whether the given error is a 403 caused by a rejected CSRF token.
+// Distinguishes from authorization 403.
+function isCsrfRejection(err: unknown): boolean {
+  return (
+    err instanceof HTTPError &&
+    err.response.status === 403 &&
+    typeof err.data === 'string' &&
+    // The CSRF middleware's body is "Forbidden - <reason>" and its token
+    // reasons contain "CSRF".
+    err.data.includes('CSRF')
+  )
 }
 
 export function preloadCsrfToken() {
@@ -453,6 +471,25 @@ export class ApiClient {
 
   private getCsrfToken(): Promise<string | undefined> {
     return getCsrfToken(this)
+  }
+
+  // Runs a CSRF-protected request, passing `run` the current token to attach as
+  // the X-CSRF-Token header.
+  //
+  // If the token has gone stale and the request is rejected for CSRF, refetches
+  // a fresh token and retries once. Other errors propagate untouched.
+  private async withCsrf<T>(
+    run: (csrfToken: string | undefined) => Promise<T>,
+  ): Promise<T> {
+    try {
+      return await run(await this.getCsrfToken())
+    } catch (err) {
+      if (isCsrfRejection(err)) {
+        invalidateCsrfToken()
+        return await run(await this.getCsrfToken())
+      }
+      throw err
+    }
   }
 
   getActivistNames = async (signal?: AbortSignal) => {
@@ -573,15 +610,16 @@ export class ApiClient {
     signal?: AbortSignal,
   ) => {
     try {
-      const csrfToken = await this.getCsrfToken()
-      const resp = await this.client
-        .patch(`${API_PATH.ACTIVIST_GET}/${activistId}`, {
-          json: patch,
-          headers: { 'X-CSRF-Token': csrfToken },
-          signal,
-        })
-        .json()
-      const activist = ActivistGetResp.parse(resp).activist
+      const activist = await this.withCsrf(async (csrfToken) => {
+        const resp = await this.client
+          .patch(`${API_PATH.ACTIVIST_GET}/${activistId}`, {
+            json: patch,
+            headers: { 'X-CSRF-Token': csrfToken },
+            signal,
+          })
+          .json()
+        return ActivistGetResp.parse(resp).activist
+      })
       fillActivistBlankFields(activist)
       return activist
     } catch (err) {
@@ -674,14 +712,15 @@ export class ApiClient {
 
   createUser = async (payload: UserWithoutId) => {
     try {
-      const csrfToken = await this.getCsrfToken()
-      const resp = await this.client
-        .post(API_PATH.USERS, {
-          json: payload,
-          headers: { 'X-CSRF-Token': csrfToken },
-        })
-        .json()
-      return UserSaveResp.parse(resp).user
+      return await this.withCsrf(async (csrfToken) => {
+        const resp = await this.client
+          .post(API_PATH.USERS, {
+            json: payload,
+            headers: { 'X-CSRF-Token': csrfToken },
+          })
+          .json()
+        return UserSaveResp.parse(resp).user
+      })
     } catch (err) {
       return this.handleKyError(err)
     }
@@ -689,14 +728,15 @@ export class ApiClient {
 
   updateUser = async (payload: User) => {
     try {
-      const csrfToken = await this.getCsrfToken()
-      const resp = await this.client
-        .put(`${API_PATH.USERS}/${payload.id}`, {
-          json: payload,
-          headers: { 'X-CSRF-Token': csrfToken },
-        })
-        .json()
-      return UserSaveResp.parse(resp).user
+      return await this.withCsrf(async (csrfToken) => {
+        const resp = await this.client
+          .put(`${API_PATH.USERS}/${payload.id}`, {
+            json: payload,
+            headers: { 'X-CSRF-Token': csrfToken },
+          })
+          .json()
+        return UserSaveResp.parse(resp).user
+      })
     } catch (err) {
       return this.handleKyError(err)
     }
@@ -704,15 +744,16 @@ export class ApiClient {
 
   sendTestEmail = async (email: string) => {
     try {
-      const csrfToken = await this.getCsrfToken()
-      const resp = await this.client
-        .post(API_PATH.ADMIN_SEND_TEST_EMAIL, {
-          json: { email },
-          headers: { 'X-CSRF-Token': csrfToken },
-        })
-        .json()
-      this.throwIfApiError(resp)
-      return SuccessResp.parse(resp)
+      return await this.withCsrf(async (csrfToken) => {
+        const resp = await this.client
+          .post(API_PATH.ADMIN_SEND_TEST_EMAIL, {
+            json: { email },
+            headers: { 'X-CSRF-Token': csrfToken },
+          })
+          .json()
+        this.throwIfApiError(resp)
+        return SuccessResp.parse(resp)
+      })
     } catch (err) {
       return this.handleKyError(err)
     }
@@ -731,15 +772,16 @@ export class ApiClient {
 
   saveEvent = async (payload: SaveEventParams) => {
     try {
-      const csrfToken = await this.getCsrfToken()
-      const resp = await this.client
-        .post(API_PATH.EVENT_SAVE, {
-          json: payload,
-          headers: { 'X-CSRF-Token': csrfToken },
-        })
-        .json()
-      this.throwIfApiError(resp)
-      return EventSaveResp.parse(resp)
+      return await this.withCsrf(async (csrfToken) => {
+        const resp = await this.client
+          .post(API_PATH.EVENT_SAVE, {
+            json: payload,
+            headers: { 'X-CSRF-Token': csrfToken },
+          })
+          .json()
+        this.throwIfApiError(resp)
+        return EventSaveResp.parse(resp)
+      })
     } catch (err) {
       return this.handleKyError(err)
     }
@@ -747,15 +789,16 @@ export class ApiClient {
 
   saveCoaching = async (payload: SaveEventParams) => {
     try {
-      const csrfToken = await this.getCsrfToken()
-      const resp = await this.client
-        .post(API_PATH.COACHING_SAVE, {
-          json: payload,
-          headers: { 'X-CSRF-Token': csrfToken },
-        })
-        .json()
-      this.throwIfApiError(resp)
-      return EventSaveResp.parse(resp)
+      return await this.withCsrf(async (csrfToken) => {
+        const resp = await this.client
+          .post(API_PATH.COACHING_SAVE, {
+            json: payload,
+            headers: { 'X-CSRF-Token': csrfToken },
+          })
+          .json()
+        this.throwIfApiError(resp)
+        return EventSaveResp.parse(resp)
+      })
     } catch (err) {
       return this.handleKyError(err)
     }
@@ -782,16 +825,17 @@ export class ApiClient {
 
   deleteEvent = async (eventId: number) => {
     try {
-      const csrfToken = await this.getCsrfToken()
       const body = new URLSearchParams({ event_id: String(eventId) })
-      const resp = await this.client
-        .post(API_PATH.EVENT_DELETE, {
-          body,
-          headers: { 'X-CSRF-Token': csrfToken },
-        })
-        .json()
-      this.throwIfApiError(resp)
-      return SuccessResp.parse(resp)
+      return await this.withCsrf(async (csrfToken) => {
+        const resp = await this.client
+          .post(API_PATH.EVENT_DELETE, {
+            body,
+            headers: { 'X-CSRF-Token': csrfToken },
+          })
+          .json()
+        this.throwIfApiError(resp)
+        return SuccessResp.parse(resp)
+      })
     } catch (err) {
       return this.handleKyError(err)
     }

--- a/frontend-v2/src/lib/api.ts
+++ b/frontend-v2/src/lib/api.ts
@@ -421,11 +421,11 @@ export class ApiClient {
     })
   }
 
-  private async handleKyError(err: unknown): Promise<never> {
+  private handleKyError(err: unknown): never {
     if (err instanceof HTTPError) {
-      const parsed = ApiErrorResp.safeParse(
-        await err.response.json().catch(() => null),
-      )
+      // ky consumes the response body when it builds the error and exposes the
+      // pre-parsed payload on err.data.
+      const parsed = ApiErrorResp.safeParse(err.data)
       if (parsed.success) {
         throw new HTTPStatusError(err.response.status, parsed.data.message)
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of expired or invalid security tokens by refreshing them and retrying affected requests once.
  * Enhanced error reporting so server-provided messages are surfaced more reliably.
  * Applied consistent security-token recovery across updates, event actions, coaching saves, and email workflows.

* **Developer Experience**
  * Improved local development access when using the IPv6 localhost address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->