### PR TITLE
feat(activists): allow editing assigned_to field

### DIFF
--- a/frontend-v2/src/app/(authed)/activists/[id]/activist-detail.test.tsx
+++ b/frontend-v2/src/app/(authed)/activists/[id]/activist-detail.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen, within, cleanup } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import {
+  API_PATH,
+  apiClient,
+  type ActivistJSON,
+  type AssignableUser,
+} from '@/lib/api'
+import { ActivistDetail } from './activist-detail'
+
+// HideActivistDialog and MergeActivistDialog and their dependencies are
+// unrelated to the existing tests at this time. Stub them out so this file can
+// focus on ActivistDetail/section-form.
+vi.mock('./hide-activist-dialog', () => ({
+  HideActivistDialog: () => null,
+}))
+vi.mock('./merge-activist-dialog', () => ({
+  MergeActivistDialog: () => null,
+}))
+
+// jsdom doesn't implement these, but Radix's Select relies on them for its
+// pointer-based open/select interactions.
+beforeAll(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {}
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {}
+  }
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+const ACTIVIST_ID = 42
+
+function renderDetail(
+  activist: ActivistJSON,
+  assignableUsers?: AssignableUser[],
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity },
+    },
+  })
+  queryClient.setQueryData([API_PATH.ACTIVIST_GET, ACTIVIST_ID], activist)
+  if (assignableUsers) {
+    queryClient.setQueryData([API_PATH.USERS_ASSIGNABLE], assignableUsers)
+  }
+  return {
+    queryClient,
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <ActivistDetail activistId={ACTIVIST_ID} />
+      </QueryClientProvider>,
+    ),
+  }
+}
+
+describe('ActivistDetail Assigned To field (read-only mode)', () => {
+  it('shows the assigned_to_name value, not the raw assigned_to id', () => {
+    renderDetail({
+      id: ACTIVIST_ID,
+      name: 'Test Activist',
+      assigned_to: 7,
+      assigned_to_name: 'Bob Jones',
+    })
+
+    const dt = screen.getByText('Assigned To')
+    const row = dt.closest('div')
+    expect(row).not.toBeNull()
+    expect(within(row!).getByText('Bob Jones')).toBeInTheDocument()
+    expect(within(row!).queryByText('7')).not.toBeInTheDocument()
+
+    // Only one "Assigned To" row should render (assigned_to_name itself is
+    // hidden on the detail page via hideOnDetailPage).
+    expect(screen.getAllByText('Assigned To')).toHaveLength(1)
+  })
+
+  it('shows a placeholder when assigned_to_name is absent', () => {
+    renderDetail({
+      id: ACTIVIST_ID,
+      name: 'Test Activist',
+    })
+
+    const dt = screen.getByText('Assigned To')
+    const row = dt.closest('div')
+    expect(within(row!).getByText('—')).toBeInTheDocument()
+  })
+})
+
+describe('ActivistDetail Assigned To field (edit mode)', () => {
+  const ASSIGNABLE_USERS: AssignableUser[] = [
+    { id: 1, name: 'Alice' },
+    { id: 2, name: 'Bob Jones' },
+  ]
+
+  it('populates the dropdown with the assignable users plus Unassigned', async () => {
+    const user = userEvent.setup()
+    renderDetail(
+      {
+        id: ACTIVIST_ID,
+        name: 'Test Activist',
+        assigned_to: 1,
+        assigned_to_name: 'Alice',
+      },
+      ASSIGNABLE_USERS,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Edit Prospect Info' }))
+
+    const trigger = screen.getByRole('combobox', { name: 'Assigned To' })
+    await user.click(trigger)
+
+    const listbox = screen.getByRole('listbox')
+    expect(within(listbox).getByText('Unassigned')).toBeInTheDocument()
+    expect(within(listbox).getByText('Alice')).toBeInTheDocument()
+    expect(within(listbox).getByText('Bob Jones')).toBeInTheDocument()
+  })
+
+  it('saves the newly selected user as assigned_to', async () => {
+    const activist: ActivistJSON = {
+      id: ACTIVIST_ID,
+      name: 'Test Activist',
+      assigned_to: 1,
+      assigned_to_name: 'Alice',
+    }
+    const patchSpy = vi.spyOn(apiClient, 'patchActivist').mockResolvedValue({
+      ...activist,
+      assigned_to: 2,
+      assigned_to_name: 'Bob Jones',
+    })
+
+    const user = userEvent.setup()
+    renderDetail(activist, ASSIGNABLE_USERS)
+
+    await user.click(screen.getByRole('button', { name: 'Edit Prospect Info' }))
+
+    const trigger = screen.getByRole('combobox', { name: 'Assigned To' })
+    await user.click(trigger)
+    await user.click(screen.getByRole('option', { name: 'Bob Jones' }))
+
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(patchSpy).toHaveBeenCalledWith(ACTIVIST_ID, { assigned_to: 2 })
+  })
+})

--- a/frontend-v2/src/app/(authed)/activists/[id]/section-form.tsx
+++ b/frontend-v2/src/app/(authed)/activists/[id]/section-form.tsx
@@ -15,7 +15,7 @@ import {
   apiClient,
   ActivistJSON,
   ActivistPatchInput,
-  type User,
+  type AssignableUser,
 } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -119,8 +119,8 @@ export function ActivistSectionForm({
     (f) => inputTypeFor(f) === 'user-select',
   )
   const usersQuery = useQuery({
-    queryKey: [API_PATH.USERS],
-    queryFn: ({ signal }) => apiClient.getUsers(signal),
+    queryKey: [API_PATH.USERS_ASSIGNABLE],
+    queryFn: ({ signal }) => apiClient.getAssignableUsers(signal),
     enabled: hasUserSelect,
   })
 
@@ -368,7 +368,7 @@ function UserSelectField({
   errorMessage,
   usersQuery,
 }: FieldComponentProps & {
-  usersQuery: UseQueryResult<User[]>
+  usersQuery: UseQueryResult<AssignableUser[]>
 }) {
   const numericValue =
     typeof field.state.value === 'number'
@@ -391,7 +391,7 @@ function UserSelectField({
           <SelectItem value={String(UNASSIGNED_USER_ID)}>Unassigned</SelectItem>
           {usersQuery.data?.map((user) => (
             <SelectItem key={user.id} value={String(user.id)}>
-              {user.name || user.email}
+              {user.name}
             </SelectItem>
           ))}
         </SelectContent>

--- a/frontend-v2/src/app/(authed)/activists/column-definitions.ts
+++ b/frontend-v2/src/app/(authed)/activists/column-definitions.ts
@@ -354,7 +354,6 @@ export const COLUMN_DEFINITIONS: ColumnDefinition[] = [
     label: 'Assigned To',
     category: 'Prospect Info',
     hidden: true,
-    hideOnDetailPage: true,
     editInputType: 'user-select',
   },
   {
@@ -362,6 +361,10 @@ export const COLUMN_DEFINITIONS: ColumnDefinition[] = [
     label: 'Assigned To',
     category: 'Prospect Info',
     defaultWidth: 200,
+    // The detail page uses 'assigned_to' as the editable field and special
+    // cases it to show the name as well while editing (via selected dropdown
+    // value) and in read-only mode.
+    hideOnDetailPage: true,
   },
   {
     name: 'followup_date',

--- a/frontend-v2/src/app/(authed)/activists/format-value.test.ts
+++ b/frontend-v2/src/app/(authed)/activists/format-value.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import type { ActivistJSON } from '@/lib/api'
+import { COLUMN_DEFINITION_BY_NAME } from './column-definitions'
+import { getReadOnlyFieldDisplay } from './format-value'
+
+describe('getReadOnlyFieldDisplay', () => {
+  it('shows assigned_to_name (not the raw id) for the assigned_to field', () => {
+    const def = COLUMN_DEFINITION_BY_NAME['assigned_to']
+    const activist: ActivistJSON = {
+      id: 1,
+      assigned_to: 5,
+      assigned_to_name: 'Alice Smith',
+    }
+
+    const display = getReadOnlyFieldDisplay(activist, def)
+
+    expect(display.value).toBe('Alice Smith')
+    expect(display.isEmpty).toBe(false)
+  })
+
+  it('shows a placeholder for assigned_to when assigned_to_name is absent', () => {
+    const def = COLUMN_DEFINITION_BY_NAME['assigned_to']
+    const activist: ActivistJSON = {
+      id: 1,
+      assigned_to: 5,
+    }
+
+    const display = getReadOnlyFieldDisplay(activist, def)
+
+    expect(display.value).toBe('—')
+    expect(display.isEmpty).toBe(true)
+  })
+
+  it('falls back to formatValue/raw value for a normal (non-assigned_to) field', () => {
+    const def = COLUMN_DEFINITION_BY_NAME['name']
+    const activist: ActivistJSON = {
+      id: 1,
+      name: 'Jane Doe',
+    }
+
+    const display = getReadOnlyFieldDisplay(activist, def)
+
+    expect(display.value).toBe('Jane Doe')
+    expect(display.isEmpty).toBe(false)
+  })
+})

--- a/frontend-v2/src/app/(authed)/activists/format-value.ts
+++ b/frontend-v2/src/app/(authed)/activists/format-value.ts
@@ -72,6 +72,17 @@ export function getReadOnlyFieldDisplay(
   activist: ActivistJSON,
   def: ColumnDefinition,
 ): ReadOnlyFieldDisplay {
+  // assigned_to is a user ID; show the paired assigned_to_name instead.
+  if (def.name === 'assigned_to') {
+    const name = activist.assigned_to_name
+    return {
+      label: def.label,
+      description: def.description,
+      linkType: def.linkType,
+      value: name || '—',
+      isEmpty: !name,
+    }
+  }
   const raw = activist[def.name as keyof ActivistJSON]
   const formatted = formatValue(raw, def.name)
   return {

--- a/frontend-v2/src/lib/api.ts
+++ b/frontend-v2/src/lib/api.ts
@@ -29,6 +29,7 @@ export const API_PATH = {
   CSRF_TOKEN: 'api/csrf-token',
   CHAPTER_LIST: 'chapter/list',
   USERS: 'api/users',
+  USERS_ASSIGNABLE: 'api/users/assignable',
   EVENT_GET: 'event/get',
   EVENT_SAVE: 'event/save',
   EVENT_LIST: 'event/list',
@@ -161,6 +162,16 @@ export type UserWithoutId = Omit<User, 'id'>
 
 const UserListResp = z.object({
   users: z.array(UserSchema),
+})
+
+const AssignableUserSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+})
+export type AssignableUser = z.infer<typeof AssignableUserSchema>
+
+const AssignableUserListResp = z.object({
+  users: z.array(AssignableUserSchema),
 })
 
 const UserSaveResp = z.object({
@@ -694,6 +705,17 @@ export class ApiClient {
     try {
       const resp = await this.client.get(API_PATH.USERS, { signal }).json()
       return UserListResp.parse(resp).users
+    } catch (err) {
+      return this.handleKyError(err)
+    }
+  }
+
+  getAssignableUsers = async (signal?: AbortSignal) => {
+    try {
+      const resp = await this.client
+        .get(API_PATH.USERS_ASSIGNABLE, { signal })
+        .json()
+      return AssignableUserListResp.parse(resp).users
     } catch (err) {
       return this.handleKyError(err)
     }

--- a/server/src/main.go
+++ b/server/src/main.go
@@ -347,6 +347,7 @@ func router() (*mux.Router, *sqlx.DB) {
 	router.Handle("/api/activists/export/spoke", alice.New(main.apiOrganizerAccessAuthMiddleware).ThenFunc(main.ActivistsExportSpokeHandler)).Methods(http.MethodPost)
 	router.Handle("/api/activists/{id:[0-9]+}", alice.New(main.apiOrganizerAccessAuthMiddleware).ThenFunc(main.ActivistGetHandler)).Methods(http.MethodGet)
 	router.Handle("/api/activists/{id:[0-9]+}", csrfMiddleware(alice.New(main.apiOrganizerAccessAuthMiddleware).ThenFunc(main.ActivistPatchHandler))).Methods(http.MethodPatch)
+	router.Handle("/api/users/assignable", alice.New(main.apiOrganizerAccessAuthMiddleware).ThenFunc(main.UsersAssignableListHandler)).Methods(http.MethodGet)
 	router.Handle("/activist_names/get", alice.New(main.apiAttendanceAuthMiddleware).ThenFunc(main.AutocompleteActivistsHandler))
 	router.Handle("/activist_names/get_organizers", alice.New(main.apiAttendanceAuthMiddleware).ThenFunc(main.AutocompleteOrganizersHandler))
 	router.Handle("/activist_names/get_chaptermembers", alice.New(main.apiAttendanceAuthMiddleware).ThenFunc(main.AutocompleteChapterMembersHandler))
@@ -1888,6 +1889,9 @@ func (c MainController) ActivistPatchHandler(w http.ResponseWriter, r *http.Requ
 
 func (c MainController) UsersListHandler(w http.ResponseWriter, r *http.Request) {
 	transport.UsersListHandler(w, r, c.userRepo)
+}
+func (c MainController) UsersAssignableListHandler(w http.ResponseWriter, r *http.Request) {
+	transport.UsersAssignableListHandler(w, r, c.userRepo)
 }
 func (c MainController) UserGetHandler(w http.ResponseWriter, r *http.Request) {
 	transport.UserGetHandler(w, r, c.userRepo)

--- a/server/src/transport/users.go
+++ b/server/src/transport/users.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -73,6 +74,39 @@ func UsersListHandler(w http.ResponseWriter, r *http.Request, repo model.UserRep
 
 	writeJSON(w, map[string]interface{}{
 		"users": usersToJson(users),
+	})
+}
+
+type AssignableUserJson struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// UsersAssignableListHandler returns a minimal id+name list of active ADB
+// users, allowing organizers to view other ADB users, e.g. to select them in
+// an "assign to" dropdown.
+// It's available at organizer-level access (unlike UsersListHandler, which is
+// admin-only and exposes full user records).
+func UsersAssignableListHandler(w http.ResponseWriter, r *http.Request, repo model.UserRepository) {
+	users, err := repo.GetUsers(model.GetUserOptions{PopulateRoles: true})
+	if err != nil {
+		sendErrorMessage(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	assignable := make([]AssignableUserJson, 0, len(users))
+	for _, u := range users {
+		if u.Disabled {
+			continue
+		}
+		assignable = append(assignable, AssignableUserJson{ID: u.ID, Name: u.Name})
+	}
+	sort.Slice(assignable, func(i, j int) bool {
+		return assignable[i].Name < assignable[j].Name
+	})
+
+	writeJSON(w, map[string]interface{}{
+		"users": assignable,
 	})
 }
 

--- a/server/src/transport/users_test.go
+++ b/server/src/transport/users_test.go
@@ -1,0 +1,113 @@
+package transport
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dxe/adb/model"
+	"github.com/dxe/adb/persistence"
+	"github.com/dxe/adb/testdb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUsersAssignableListHandler_FiltersDisabledAndSortsByName(t *testing.T) {
+	db := testdb.NewDB()
+	defer func() { _ = db.Close() }()
+
+	userRepo := persistence.NewUserRepository(db)
+
+	// testdb.NewDB() already seeds a non-disabled "Dev User" (model.DevTestUserId).
+	_, err := userRepo.CreateUser(model.ADBUser{
+		Email:     "zoe@example.org",
+		Name:      "Zoe Zimmerman",
+		ChapterID: model.SFBayChapterIdDevTest,
+	})
+	require.NoError(t, err)
+
+	_, err = userRepo.CreateUser(model.ADBUser{
+		Email:     "alice@example.org",
+		Name:      "Alice Adams",
+		ChapterID: model.SFBayChapterIdDevTest,
+	})
+	require.NoError(t, err)
+
+	_, err = userRepo.CreateUser(model.ADBUser{
+		Email:     "disabled@example.org",
+		Name:      "Debbie Disabled",
+		ChapterID: model.SFBayChapterIdDevTest,
+		Disabled:  true,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/users/assignable", nil)
+	rec := httptest.NewRecorder()
+
+	UsersAssignableListHandler(rec, req, userRepo)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Users []AssignableUserJson `json:"users"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+
+	var names []string
+	for _, u := range resp.Users {
+		names = append(names, u.Name)
+	}
+
+	// The disabled user must be excluded, and the rest sorted by name ascending.
+	require.Equal(t, []string{"Alice Adams", "Dev User", "Zoe Zimmerman"}, names)
+}
+
+func TestUsersAssignableListHandler_OnlyExposesIDAndName(t *testing.T) {
+	db := testdb.NewDB()
+	defer func() { _ = db.Close() }()
+
+	userRepo := persistence.NewUserRepository(db)
+
+	created, err := userRepo.CreateUser(model.ADBUser{
+		Email:     "someone@example.org",
+		Name:      "Someone Else",
+		ChapterID: model.SFBayChapterIdDevTest,
+		Roles:     []string{"organizer"},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/users/assignable", nil)
+	rec := httptest.NewRecorder()
+
+	UsersAssignableListHandler(rec, req, userRepo)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	body := rec.Body.String()
+	require.NotContains(t, body, `"email"`)
+	require.NotContains(t, body, `"roles"`)
+	require.NotContains(t, body, `"disabled"`)
+	require.NotContains(t, body, `"chapter_id"`)
+
+	var resp struct {
+		Users []map[string]interface{} `json:"users"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &resp))
+
+	found := false
+	for _, u := range resp.Users {
+		if int(u["id"].(float64)) == created.ID {
+			found = true
+			require.ElementsMatch(t, []string{"id", "name"}, keysOf(u))
+		}
+	}
+	require.True(t, found, "expected created user %d to be present in assignable list", created.ID)
+}
+
+func keysOf(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an assignee selector that lists only active, assignable users.
  * Assignee options are sorted by name and display names only.
  * Added clearer read-only assignee display, including an unassigned placeholder.

* **Bug Fixes**
  * Updated activist detail and editing views to show assigned users consistently.

* **Tests**
  * Added coverage for assignee selection, display behavior, filtering, sorting, and response data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->