### PR TITLE
chore: set devcontainer ram limits

### DIFF
--- a/.devcontainer/compose.extend.yaml
+++ b/.devcontainer/compose.extend.yaml
@@ -11,6 +11,9 @@ services:
     # Override default command to keep devcontainer alive as default command
     # could exit immediately. Command taken from VS Code devcontainer docs.
     command: /bin/sh -c "while sleep 1000; do :; done"
+    # Cap container RAM with no swap (memswap_limit == mem_limit disables swap).
+    mem_limit: 8g
+    memswap_limit: 8g
     environment:
       - DB_HOST=mysql
       - DB_PROTOCOL=tcp(mysql:3306)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -68,7 +68,6 @@
       "extensions": [
         "ms-vscode.makefile-tools",
         "golang.go",
-        "Vue.volar",
         "GitHub.vscode-github-actions",
         "ms-vscode.vscode-typescript-next",
         "esbenp.prettier-vscode",

--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,9 @@ dev_db:
 # Note: PNPM must be installed separately for each version of NPM used, since it is installed within each NPM installation.
 # Note: `go tool` cannot yet be used to install golang-migrate: https://github.com/golang-migrate/migrate/issues/1232
 deps:
-	# Ensure server/.env exists. Both `make run` and the VS Code "Go Server"
-	# launch config load it unconditionally (layered on server/debug.env) and
-	# error if it's missing, so deps (the required first step) creates it.
+	@# Ensure server/.env exists. Both `make run` and the VS Code "Go Server"
+	@# launch config load it unconditionally (layered on server/debug.env) and
+	@# error if it's missing, so deps (the required first step) creates it.
 	touch server/.env
 	. $(NVM_SCRIPT) && nvm i 22 && npm i -g pnpm@$(PNPM_VERSION) && pnpm i --config.confirmModulesPurge=false
 	. $(NVM_SCRIPT) && cd frontend && nvm i $(VUE_FRONTEND_NODE_VERSION) && npm i --legacy-peer-deps

--- a/server/compose.yaml
+++ b/server/compose.yaml
@@ -14,6 +14,7 @@ services:
     volumes:
       - mysql-data:/var/lib/mysql
       - ./scripts/init.sql:/docker-entrypoint-initdb.d/init.sql
+    mem_limit: 1g
 
 volumes:
   mysql-data: {}


### PR DESCRIPTION
also remove vue extension. generally we should perhaps avoid rarely used extensions.