### PR TITLE
Accept the Google Groups sync key as a value, not just a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ Please reach out to tech@dxe.io to get an API key to sign people up.
 
 ### For syncing with a chapter's internal Google Groups (for example, working group lists):
 
-- SYNC_MAILING_LISTS_CONFIG_FILE: relative path to client_secrets.json if syncing with google groups
+- SYNC_MAILING_LISTS_CONFIG_JSON: the contents of client_secrets.json, for a deployment that injects secrets as environment variables rather than files
+- SYNC_MAILING_LISTS_CONFIG_FILE: relative path to client_secrets.json, if the above is not set
 - SYNC_MAILING_LISTS_OAUTH_SUBJECT: google account to use to sync
 
 ### For sending emails via SMTP:

--- a/server/src/config/config.go
+++ b/server/src/config/config.go
@@ -37,11 +37,15 @@ var (
 	DistDirectory      = mustGetenv("DIST_DIRECTORY", "./dist", false)
 	NextJsProxyUrl     = mustGetenv("NEXT_JS_PROXY_URL", "", false)
 
-	// Path to Google API oauth client_secrets.json file, with
-	// access to the following scope:
+	// Google API oauth service-account key, with access to the following scope:
 	// https://www.googleapis.com/auth/admin.directory.group
 	// And the "Admin" API enabled. More info:
 	//   https://developers.google.com/api-client-library/python/auth/service-accounts
+	//
+	// Give it as either the client_secrets.json contents themselves or a path to
+	// a file holding them; the contents win if both are set. A secret store can
+	// usually inject a value into the environment but not mount it as a file.
+	SyncMailingListsConfigJSON = mustGetenv("SYNC_MAILING_LISTS_CONFIG_JSON", "", false)
 	SyncMailingListsConfigFile = mustGetenv("SYNC_MAILING_LISTS_CONFIG_FILE", "", false)
 
 	// The email for the user that that the oauth account should

--- a/server/src/google_groups_sync/google_groups_sync.go
+++ b/server/src/google_groups_sync/google_groups_sync.go
@@ -2,6 +2,7 @@ package google_groups_sync
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -16,10 +17,23 @@ import (
 	admin "google.golang.org/api/admin/directory/v1"
 )
 
-func getAdminService() (*admin.Service, error) {
+// serviceAccountKey returns the Google service-account key, from the
+// environment when it is set there and from a file otherwise.
+func serviceAccountKey() ([]byte, error) {
+	if config.SyncMailingListsConfigJSON != "" {
+		return []byte(config.SyncMailingListsConfigJSON), nil
+	}
 	key, err := os.ReadFile(config.SyncMailingListsConfigFile)
 	if err != nil {
-		return nil, errors.Wrap(err, "Could not read google auth key")
+		return nil, fmt.Errorf("could not read google auth key: %w", err)
+	}
+	return key, nil
+}
+
+func getAdminService() (*admin.Service, error) {
+	key, err := serviceAccountKey()
+	if err != nil {
+		return nil, err
 	}
 	oauthConfig, err := google.JWTConfigFromJSON(key, "https://www.googleapis.com/auth/admin.directory.group")
 	if err != nil {
@@ -275,7 +289,7 @@ func syncMailingListsWrapper(db *sqlx.DB, adminService *admin.Service) {
 // goroutine.
 func StartMailingListsSync(db *sqlx.DB) {
 
-	if config.SyncMailingListsConfigFile == "" {
+	if config.SyncMailingListsConfigJSON == "" && config.SyncMailingListsConfigFile == "" {
 		log.Println("WARNING: Sync mailing list config invalid.")
 		return
 	}

--- a/server/src/google_groups_sync/google_groups_sync_test.go
+++ b/server/src/google_groups_sync/google_groups_sync_test.go
@@ -1,10 +1,41 @@
 package google_groups_sync
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/dxe/adb/config"
 	"github.com/stretchr/testify/require"
 )
+
+func TestServiceAccountKey(t *testing.T) {
+	origJSON, origFile := config.SyncMailingListsConfigJSON, config.SyncMailingListsConfigFile
+	t.Cleanup(func() {
+		config.SyncMailingListsConfigJSON, config.SyncMailingListsConfigFile = origJSON, origFile
+	})
+
+	path := filepath.Join(t.TempDir(), "client_secrets.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"from":"file"}`), 0600))
+
+	// The file is read when only it is set.
+	config.SyncMailingListsConfigJSON, config.SyncMailingListsConfigFile = "", path
+	key, err := serviceAccountKey()
+	require.NoError(t, err)
+	require.Equal(t, `{"from":"file"}`, string(key))
+
+	// The environment wins when both are set, so a deployment that injects the
+	// key as a variable does not also need the file to exist.
+	config.SyncMailingListsConfigJSON = `{"from":"env"}`
+	key, err = serviceAccountKey()
+	require.NoError(t, err)
+	require.Equal(t, `{"from":"env"}`, string(key))
+
+	// A missing file is still an error rather than an empty key.
+	config.SyncMailingListsConfigJSON, config.SyncMailingListsConfigFile = "", path+".nope"
+	_, err = serviceAccountKey()
+	require.Error(t, err)
+}
 
 func TestGetInsertAndRemoveEmails(t *testing.T) {
 	// Should not add/remove activists if the list is empty.


### PR DESCRIPTION
The mailing list sync reads its service-account key with `os.ReadFile`, so the only way to supply it is a file on disk — srv1 bind-mounts one into the container. A secret store can inject a value into the environment but cannot mount one as a file, so moving this service anywhere managed means writing the key out in an entrypoint wrapper before the binary starts.

`SYNC_MAILING_LISTS_CONFIG_JSON` takes the `client_secrets.json` contents directly and wins when both are set. The file path still works unchanged, which is what local development and srv1 use.

This is a prerequisite for [dxe/terraform#36](https://github.com/dxe/terraform/pull/36), which moves `adb` to ECS. Without it, the `adb-jobs` task definition has to override the entrypoint with a `printf … > /tmp/client_secrets.json && exec ./run.sh` shell wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)