### PR TITLE
Deploy to ECS on push, instead of relying on Watchtower

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,12 +166,15 @@ jobs:
         # Required for the gha cache backend below; the default docker driver
         # cannot export a registry/gha build cache.
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - name: Short sha
+        id: sha
+        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
       - name: Build and push image to ECR (main)
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           push: true
-          tags: ${{ steps.login-ecr.outputs.registry }}/dxe/adb:${{ github.sha }}
+          tags: ${{ steps.login-ecr.outputs.registry }}/dxe/adb:${{ steps.sha.outputs.short }}
           # Distinct scope so the two images don't clobber each other's cache.
           cache-from: type=gha,scope=server
           cache-to: type=gha,scope=server,mode=max
@@ -192,14 +195,51 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@03f1aad4c6c7ffd436567f42f9384779290529bd # v2
-      - name: Retag :${{ github.sha }} as :latest
+      - name: Short sha
+        id: sha
+        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+      - name: Retag :${{ steps.sha.outputs.short }} as :latest
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          SHA: ${{ github.sha }}
+          SHA: ${{ steps.sha.outputs.short }}
         run: |
           docker buildx imagetools create \
             --tag "$REGISTRY/dxe/adb:latest" \
             "$REGISTRY/dxe/adb:$SHA"
+
+  # Tell dxe/terraform to deploy the image promote-server just published: it
+  # bumps the tag in ecs.tf and pushes that commit to main, where apply-deploy.yml
+  # applies it. Terraform is the only thing that writes to an ECS service, so
+  # `git log ecs.tf` is the release history and a rollback is `git revert`.
+  #
+  # Dispatched over the API rather than called with `uses:`. A reusable workflow
+  # in a private repo cannot be called by a public one, and this repo is public —
+  # that fails at *parse* time and takes the whole run down with it, silently
+  # stopping image pushes.
+  #
+  # Gated on the promote job, so it inherits `needs: test`: a deploy only happens
+  # once the test suite has passed.
+  deploy-server:
+    needs: [promote-server, changes]
+    if: ${{ github.event_name == 'push' && needs.changes.outputs.server == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint a token that may dispatch in dxe/terraform
+        id: token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.0.0
+        with:
+          client-id: ${{ secrets.DEPLOY_APP_CLIENT_ID }}
+          private-key: ${{ secrets.DEPLOY_APP_PRIVATE_KEY }}
+          owner: dxe
+          repositories: terraform
+      - name: Trigger the deploy
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          gh workflow run deploy-ecs.yml --repo dxe/terraform \
+            -f service=adb \
+            -f tag="${GITHUB_SHA::7}" \
+            -f caller_run_id=${{ github.run_id }}
 
   # Build and push the Next.js image under an immutable :<sha> tag, in parallel
   # with `test` (see build-server for the rationale).
@@ -220,13 +260,16 @@ jobs:
         uses: aws-actions/amazon-ecr-login@03f1aad4c6c7ffd436567f42f9384779290529bd # v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - name: Short sha
+        id: sha
+        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
       - name: Build and push image to ECR (next.js)
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: Dockerfile.frontend-v2
           push: true
-          tags: ${{ steps.login-ecr.outputs.registry }}/dxe/adb-next:${{ github.sha }}
+          tags: ${{ steps.login-ecr.outputs.registry }}/dxe/adb-next:${{ steps.sha.outputs.short }}
           cache-from: type=gha,scope=next
           cache-to: type=gha,scope=next,mode=max
 
@@ -245,14 +288,56 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@03f1aad4c6c7ffd436567f42f9384779290529bd # v2
-      - name: Retag :${{ github.sha }} as :latest
+      - name: Short sha
+        id: sha
+        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+      - name: Retag :${{ steps.sha.outputs.short }} as :latest
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          SHA: ${{ github.sha }}
+          SHA: ${{ steps.sha.outputs.short }}
         run: |
           docker buildx imagetools create \
             --tag "$REGISTRY/dxe/adb-next:latest" \
             "$REGISTRY/dxe/adb-next:$SHA"
+
+  # Tell dxe/terraform to deploy the image promote-frontend just published: it
+  # bumps the tag in ecs.tf and pushes that commit to main, where apply-deploy.yml
+  # applies it. Terraform is the only thing that writes to an ECS service, so
+  # `git log ecs.tf` is the release history and a rollback is `git revert`.
+  #
+  # Dispatched over the API rather than called with `uses:`. A reusable workflow
+  # in a private repo cannot be called by a public one, and this repo is public —
+  # that fails at *parse* time and takes the whole run down with it, silently
+  # stopping image pushes.
+  #
+  # Gated on the promote job, so it inherits `needs: test`: a deploy only happens
+  # once the test suite has passed.
+  #
+  # `service` here is adb-next, which is a *container* rather than an entry in
+  # local.services — it is the sidecar in the adb task. deploy-ecs.yml only uses
+  # the name to pick the ECR repository (dxe/adb-next) and to label the commit,
+  # so this bumps the sidecar's image line and rolls the adb task.
+  deploy-frontend:
+    needs: [promote-frontend, changes]
+    if: ${{ github.event_name == 'push' && needs.changes.outputs.frontend == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint a token that may dispatch in dxe/terraform
+        id: token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.0.0
+        with:
+          client-id: ${{ secrets.DEPLOY_APP_CLIENT_ID }}
+          private-key: ${{ secrets.DEPLOY_APP_PRIVATE_KEY }}
+          owner: dxe
+          repositories: terraform
+      - name: Trigger the deploy
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          gh workflow run deploy-ecs.yml --repo dxe/terraform \
+            -f service=adb-next \
+            -f tag="${GITHUB_SHA::7}" \
+            -f caller_run_id=${{ github.run_id }}
 
   # Build and deploy the jobs lambdas via SAM. us-west-2 matches jobs/Makefile.
   deploy-lambdas:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -207,18 +207,9 @@ jobs:
             --tag "$REGISTRY/dxe/adb:latest" \
             "$REGISTRY/dxe/adb:$SHA"
 
-  # Tell dxe/terraform to deploy the image promote-server just published: it
-  # bumps the tag in ecs.tf and pushes that commit to main, where apply-deploy.yml
-  # applies it. Terraform is the only thing that writes to an ECS service, so
-  # `git log ecs.tf` is the release history and a rollback is `git revert`.
-  #
-  # Dispatched over the API rather than called with `uses:`. A reusable workflow
-  # in a private repo cannot be called by a public one, and this repo is public —
-  # that fails at *parse* time and takes the whole run down with it, silently
-  # stopping image pushes.
-  #
-  # Gated on the promote job, so it inherits `needs: test`: a deploy only happens
-  # once the test suite has passed.
+  # Bumps the image tag in dxe/terraform's ecs.tf, which applies and rolls the
+  # ECS service. Dispatched, not `uses:` — a private reusable workflow cannot be
+  # called by this public repo.
   deploy-server:
     needs: [promote-server, changes]
     if: ${{ github.event_name == 'push' && needs.changes.outputs.server == 'true' }}
@@ -232,13 +223,16 @@ jobs:
           private-key: ${{ secrets.DEPLOY_APP_PRIVATE_KEY }}
           owner: dxe
           repositories: terraform
+      - name: Short sha
+        id: sha
+        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
       - name: Trigger the deploy
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           gh workflow run deploy-ecs.yml --repo dxe/terraform \
             -f service=adb \
-            -f tag="${GITHUB_SHA::7}" \
+            -f tag="${{ steps.sha.outputs.short }}" \
             -f caller_run_id=${{ github.run_id }}
 
   # Build and push the Next.js image under an immutable :<sha> tag, in parallel
@@ -300,23 +294,8 @@ jobs:
             --tag "$REGISTRY/dxe/adb-next:latest" \
             "$REGISTRY/dxe/adb-next:$SHA"
 
-  # Tell dxe/terraform to deploy the image promote-frontend just published: it
-  # bumps the tag in ecs.tf and pushes that commit to main, where apply-deploy.yml
-  # applies it. Terraform is the only thing that writes to an ECS service, so
-  # `git log ecs.tf` is the release history and a rollback is `git revert`.
-  #
-  # Dispatched over the API rather than called with `uses:`. A reusable workflow
-  # in a private repo cannot be called by a public one, and this repo is public —
-  # that fails at *parse* time and takes the whole run down with it, silently
-  # stopping image pushes.
-  #
-  # Gated on the promote job, so it inherits `needs: test`: a deploy only happens
-  # once the test suite has passed.
-  #
-  # `service` here is adb-next, which is a *container* rather than an entry in
-  # local.services — it is the sidecar in the adb task. deploy-ecs.yml only uses
-  # the name to pick the ECR repository (dxe/adb-next) and to label the commit,
-  # so this bumps the sidecar's image line and rolls the adb task.
+  # As deploy-server. adb-next is the sidecar container, not a service key;
+  # deploy-ecs.yml only uses the name to pick the ECR repo and label the commit.
   deploy-frontend:
     needs: [promote-frontend, changes]
     if: ${{ github.event_name == 'push' && needs.changes.outputs.frontend == 'true' }}
@@ -330,13 +309,16 @@ jobs:
           private-key: ${{ secrets.DEPLOY_APP_PRIVATE_KEY }}
           owner: dxe
           repositories: terraform
+      - name: Short sha
+        id: sha
+        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
       - name: Trigger the deploy
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           gh workflow run deploy-ecs.yml --repo dxe/terraform \
             -f service=adb-next \
-            -f tag="${GITHUB_SHA::7}" \
+            -f tag="${{ steps.sha.outputs.short }}" \
             -f caller_run_id=${{ github.run_id }}
 
   # Build and deploy the jobs lambdas via SAM. us-west-2 matches jobs/Makefile.


### PR DESCRIPTION
adb moved to ECS, so `:latest` no longer deploys anything — nothing polls it any more. Until now a merge built and promoted an image that nothing then rolled out, and `ecs.tf` stayed pinned to whatever sha was there, so deploys were manual.

Each promote job now dispatches `deploy-ecs.yml` in `dxe/terraform`, which bumps the tag in `ecs.tf` and pushes to `main`, where `apply-deploy.yml` applies it. Terraform is the only thing that writes to an ECS service, so `git log ecs.tf` becomes the release history and a rollback is `git revert`.

**Two dispatches, not one.** The server and the Next.js frontend already build and promote independently behind the paths filter, and this keeps that. The frontend passes `service=adb-next` — the sidecar container, not an entry in `local.services`. `deploy-ecs.yml` only uses the name to pick the ECR repo and label the commit, so it bumps the sidecar's image line and rolls the `adb` task. I verified the tag-rewrite regex is unambiguous: `dxe/adb:` and `dxe/adb-next:` each match exactly once in `ecs.tf`, and `dxe/adb:` does not match the `adb-next` line.

**Tags become the short sha**, which is what `deploy-ecs.yml` expects and what every other DxE app publishes. `:latest` is still retagged — nothing on ECS reads it, but it stays useful for pulling locally.

Gated on the promote jobs, so a deploy inherits `needs: test` and only happens once the suite has passed.

### Before merging

`dxe/adb` needs to be on the selected-repositories list for the `DEPLOY_APP_CLIENT_ID` and `DEPLOY_APP_PRIVATE_KEY` org secrets, and the `dxe-deploy-bot` app needs **Actions: Read and write** on `dxe/terraform`. Without that the deploy job fails on a 404 from `gh workflow run` — the build and promote jobs still succeed, so an image is published but nothing rolls it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)